### PR TITLE
Retour URL CAS au Logout

### DIFF
--- a/POSS2.class.php
+++ b/POSS2.class.php
@@ -107,7 +107,7 @@ class POSS2 {
 			session_destroy();
 			return array("success"=>"ok", "url"=>Cas::getUrl()."/logout");
 		} else {
-			return array("error"=>"Aucun seller n'est logué.");
+			return array("error"=>"Aucun seller n'est logué.", "url"=>Cas::getUrl()."/logout");
 		}
 	}
 


### PR DESCRIPTION
Même si le user n'est plus loggué, on a besoin de l'URL du CAS dans le client pour déconnecter l'utilisateur du CAS.
