### PR TITLE
Fix notice dans paybox

### DIFF
--- a/class/Paybox.class.php
+++ b/class/Paybox.class.php
@@ -116,7 +116,7 @@ NULL ,  '%u',  'W',  '%u', NOW( ) , NULL , NULL , NULL ,  '%s',  '%u', NULL
       $ref_pos = strrpos( $ref, ';' );
       $ref = substr($ref,0,$ref_pos);
 
-      $auto=$_GET['auto'];
+      $auto= !empty($_GET['auto']) ? $_GET['auto'] : '';
       $trans=$_GET['trans'];
       $erreur=$_GET['erreur'];
       $db = Db_buckutt::getInstance();


### PR DESCRIPTION
Il semble que ce paramètre ne soit pas toujours spécifié, donc il faut le tester.

Corrige les erreurs :
   [Fri Oct 26 20:19:45 2012] [error] [client xxx] PHP Notice: Undefined index: auto in /server/class/Paybox.class.php on line 119
