### PR TITLE
Autoriser le bypass de ginger depuis la config

### DIFF
--- a/MADMIN.class.php
+++ b/MADMIN.class.php
@@ -97,10 +97,10 @@ class MADMIN extends WsdlBase {
 	}
 	
 	// On vérifie que le user est bien cotisant
-	$ginger = new Ginger($_CONFIG['ginger_key']);
 	try {
-        if(empty($_CONFIG['skip_ginger']) || !$_CONFIG['skip_ginger'])
+        if(!empty($_CONFIG['ginger_key']))
         {
+            $ginger = new Ginger($_CONFIG['ginger_key']);
             $user = $ginger->getUser($this->loginToRegister);
         }
         else 

--- a/MADMIN.class.php
+++ b/MADMIN.class.php
@@ -99,7 +99,20 @@ class MADMIN extends WsdlBase {
 	// On vérifie que le user est bien cotisant
 	$ginger = new Ginger($_CONFIG['ginger_key']);
 	try {
-	    $user = $ginger->getUser($this->loginToRegister);
+        if(empty($_CONFIG['skip_ginger']) || !$_CONFIG['skip_ginger'])
+        {
+            $user = $ginger->getUser($this->loginToRegister);
+        }
+        else 
+        {
+            $user = new StdClass;
+            $user->login = $this->loginToRegister;
+            $user->prenom = "Test";
+            $user->nom = "User";
+            $user->email = "payutc-test@assos.utc.fr";
+            $user->badge_uid = "123456AB";
+            $user->is_cotisant = true;
+        }
 	}
 	catch (Exception $ex) {
 	    return array("error"=>400, "error_msg"=>"Utilisateur introuvable dans Ginger (".$ex->getCode().")");

--- a/POSS2.class.php
+++ b/POSS2.class.php
@@ -267,7 +267,7 @@ ORDER BY obj_name;", array($right_POI_FUNDATION, $this->Point_id, $this->Fun_id)
 			// Verifier que le buyer existe
 			$buyer = new User($badge_id, MEAN_OF_LOGIN_BADGE, "", 0, 1, 1);
 			$state = $buyer->getState();
-			if($state != 1)
+			if($state != 1 && !empty($_CONFIG['ginger_key']))
 			{
 				// CHECK BADGE ID IN API
 				$ginger = new Ginger($_CONFIG['ginger_key']);

--- a/class/User.class.php
+++ b/class/User.class.php
@@ -571,7 +571,7 @@ class User {
 		if($this->adult == 1) {
 			return 1;
 		}
-		else {
+		else if(!empty($_CONFIG['ginger_key'])){
 			// On verifie via l'api de la dsi si le statut de la personne à changé.
 			$ginger = new Ginger($_CONFIG['ginger_key']);
 			try {
@@ -588,6 +588,7 @@ class User {
 				return 0;
 			}
 		}
+		return 1;
 	}
 
 	/**

--- a/config.inc.dist.php
+++ b/config.inc.dist.php
@@ -59,8 +59,7 @@ $_CONFIG['PBX_PUBPEM'] = "somewhere/pubkey.pem";
 
 
 // Configuration de ginger (outil cotisant)
-// Indiquer true au deuxième paramètre pour les tests
+// Laisser la clé vide pour désactiver les appels à ginger
 $_CONFIG['ginger_key'] = "abc";
-$_CONFIG['skip_ginger'] = false;
 
 ?>

--- a/config.inc.dist.php
+++ b/config.inc.dist.php
@@ -58,6 +58,9 @@ $_CONFIG['PBX_EXE'] = "/usr/share/buckutt/modulev3.cgi";
 $_CONFIG['PBX_PUBPEM'] = "somewhere/pubkey.pem";
 
 
+// Configuration de ginger (outil cotisant)
+// Indiquer true au deuxième paramètre pour les tests
 $_CONFIG['ginger_key'] = "abc";
+$_CONFIG['skip_ginger'] = false;
 
 ?>


### PR DESCRIPTION
Lorsqu'on est en local ou pour les futurs tests, on peut avoir besoin de bypasser ginger.

C'est maintenant possible avec un paramètre de config. En mode test, des infos bidons sont renvoyées pour l'utilisateur.
