### PR TITLE
Déplacement référence

### DIFF
--- a/POSS2.class.php
+++ b/POSS2.class.php
@@ -84,7 +84,7 @@ class POSS2 {
 		}
 		$this->Point_id = $poi_id;
 		$this->Fun_id = $fun_id;
-		$right = new CheckRight($user->getId(), $this->Point_id, &$this->Fun_id);
+		$right = new CheckRight($user->getId(), $this->Point_id, $this->Fun_id);
 		if(!$right->check("VENDRE"))
             return array("error"=>400, "error_msg"=>"Vous n'avez pas le droit VENDRE sur cette fundation.");
         if(!$right->check("POI-FUNDATION"))

--- a/class/CheckRight.class.php
+++ b/class/CheckRight.class.php
@@ -28,7 +28,7 @@ class CheckRight {
 	 * @param string $right
 	 * @return void
      */
-    public function __construct($user_id, $poi_id, $fun_id)
+    public function __construct($user_id, $poi_id, &$fun_id)
     {
         $this->db = Db_buckutt::getInstance();
         $this->user_id = $user_id;


### PR DESCRIPTION
En PHP 5.4, la référence doit être côté déclaration et non pas appel
