### PR TITLE
Indiquer que getInstance de la classe Db est une statique

### DIFF
--- a/db/Db_buckutt.class.php
+++ b/db/Db_buckutt.class.php
@@ -48,7 +48,7 @@ class Db_buckutt {
      * Recupere une instance de DB
      * @return object $instance
      */
-    public function getInstance()
+    public static function getInstance()
     {
 		global $_CONFIG;
         if (! isset (self::$instance))


### PR DESCRIPTION
Obligatoire en PHP 5.4
