### PR TITLE
Keymanager service

### DIFF
--- a/class/Application.class.php
+++ b/class/Application.class.php
@@ -101,18 +101,20 @@ class Application {
     /*
      * to_array()
      */
-    public function to_array()
+    public function to_array($key=1)
     {
         $application = Array(
             "app_id" => $this->app_id,
             "app_url" => $this->app_url,
-            "app_key" => $this->app_key,
             "app_name" => $this->app_name,
             "app_desc" => $this->app_desc,
             "app_creator" => $this->app_creator,
             "app_lastuse" => $this->app_lastuse,
             "app_created" => $this->app_created);
+        if($key)
+            $application["app_key"] = $this->app_key;
         return $application;
     }
 	
 }
+

--- a/class/Application.class.php
+++ b/class/Application.class.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Application.class
+ * 
+ * Classe gérant les Applications
+ */
+
+
+require_once 'db/Db_buckutt.class.php';
+require_once 'db/Mysql.class.php';
+
+class Application {
+    protected $db;
+    protected $app_id;
+    protected $app_url;     // URL du service CAS, doit correspondre pour l'auth CAS.
+    protected $app_key;     // Clef d'application, ne peut pas être changé
+    protected $app_name;    // Nom de l'application
+    protected $app_desc;    // Description de l'application
+    protected $app_creator; // Login utc du createur de l'application
+    protected $app_lastuse; // Dernière utilisation de l'application
+    protected $app_created; // Date de création de l'application
+
+
+    public function __construct() {
+        $this->db = Db_buckutt::getInstance();        
+    }
+    
+    /**
+     * Init the application from DB for a given key
+     */
+	public function from_key($key) {
+        $this->app_key = $key;
+        $query = $this->db->query("SELECT app_id, app_url, app_key, app_name, app_desc, app_creator, app_lastuse, 
+                                app_created FROM t_application_app WHERE app_key = '%s' and app_removed is NULL;", 
+                                Array($this->app_key));		
+        $row = $this->db->fetchArray($query);
+        if ($this->db->affectedRows() != 1) {
+            throw new Exception("La clef d'application n'a pas été reconnu !");
+        }
+        $this->from_array($row);
+    }
+    
+    /*
+     * Init the application from a given id
+     */
+    public function from_id($id) {
+        $this->app_id = $id;
+        $query = $this->db->query("SELECT app_id, app_url, app_key, app_name, app_desc, app_creator, app_lastuse, 
+                                app_created FROM t_application_app WHERE app_id = '%u' and app_removed is NULL;", 
+                                Array($this->app_id));		
+        $row = $this->db->fetchArray($query);
+        if ($this->db->affectedRows() != 1) {
+            throw new Exception("Il n'existe pas d'application correspondant à cet ID !");
+        }
+        $this->from_array($row);
+    }
+    
+    /*
+     * For a given row, instantiate the Application attributes
+     */
+    public function from_array($row) {
+        $this->app_id = $row['app_id'];
+        $this->app_url = $row['app_url'];
+        $this->app_key = $row['app_key'];
+        $this->app_name = $row['app_name'];
+        $this->app_desc = $row['app_desc'];
+        $this->app_creator = $row['app_creator'];
+        $this->app_lastuse = $row['app_lastuse'];
+        $this->app_created = $row['app_created'];
+    }
+    
+    
+    /*
+     * Function for creating a key...
+     */
+    private function rand_sha1($length) {
+        $max = ceil($length / 40);
+        $random = '';
+        for ($i = 0; $i < $max; $i ++) {
+            $random .= sha1(microtime(true).mt_rand(10000,90000));
+        }
+        return substr($random, 0, $length);
+    }
+
+    /*
+     * Insert a key
+     */
+    public function insert()
+    {
+        // Calculate a key
+        $this->app_key = $this->rand_sha1(32);
+        $this->db->query("INSERT INTO t_application_app (app_url, app_key, app_name, app_desc, app_creator, app_created) VALUES('%s', '%s', '%s', '%s', '%s', NOW());", 
+                         Array($this->app_url, $this->app_key, $this->app_name, $this->app_desc, $this->app_creator));
+		if ($this->db->affectedRows() != 1)
+            throw Exception("DB ERROR !");
+        // Update app_id
+        $this->app_id = $this->db->insertId();
+    }
+    
+    /*
+     * to_array()
+     */
+    public function to_array()
+    {
+        $application = Array(
+            "app_id" => $this->app_id,
+            "app_url" => $this->app_url,
+            "app_key" => $this->app_key,
+            "app_name" => $this->app_name,
+            "app_desc" => $this->app_desc,
+            "app_creator" => $this->app_creator,
+            "app_lastuse" => $this->app_lastuse,
+            "app_created" => $this->app_created);
+        return $application;
+    }
+	
+}

--- a/class/ApplicationList.class.php
+++ b/class/ApplicationList.class.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * ApplicationList.class
+ * 
+ * Classe permettant de récupérer plusieurs applications en même temps
+ */
+
+
+require_once 'db/Db_buckutt.class.php';
+require_once 'db/Mysql.class.php';
+require_once 'class/Application.class.php';
+
+class ApplicationList {
+    protected $db;
+    protected $apps;
+
+    public function __construct() {
+        $this->db = Db_buckutt::getInstance();        
+    }
+    
+    /**
+     * Get applications for a given user
+     */
+	public function from_login($login) {
+        $apps = array();
+        $query = $this->db->query("SELECT app_id, app_url, app_key, app_name, app_desc, app_creator, app_lastuse, 
+                                app_created FROM t_application_app WHERE app_creator = '%s' and app_removed is NULL;", 
+                                Array($login));	
+        if ($this->db->affectedRows() >= 1) {
+			while ($don = $this->db->fetchArray($query)) {
+                $app = new Application();
+                $app->from_array($don);
+				array_push($apps, $app);
+			}
+        }
+        $this->apps = $apps;
+    }
+    
+    /**
+     * Extract Application under an array format
+     */
+    public function to_array($key=0) {
+        $return = array();
+        foreach($this->apps as $app)
+        {
+            array_push($return, $app->to_array($key=$key));
+        }
+        return $return;
+    }
+
+	
+}
+

--- a/class/ServiceBase.class.php
+++ b/class/ServiceBase.class.php
@@ -86,7 +86,7 @@ class ServiceBase {
         if($this->user)
 			unset($this->user);
         if($this->app)
-            unset($this->app);
+            unset($this->application);
         session_destroy();
         return "ok";
 	}

--- a/class/ServiceBase.class.php
+++ b/class/ServiceBase.class.php
@@ -35,9 +35,12 @@ require_once 'class/Image.class.php';
 require_once 'class/Point.class.php';
 require_once 'class/ComplexData.class.php';
 require_once 'class/Cas.class.php';
+require_once 'class/Application.class.php';
 
 class ServiceBase {
     protected $db;
+    protected $user;
+    protected $application;
 	
     /**
     * Constructeur
@@ -45,6 +48,89 @@ class ServiceBase {
     public function __construct() {
         $this->db = Db_buckutt::getInstance();
     }
+
+    /**
+	 * Connecter le user avec un ticket CAS.
+	 * 
+	 * @param String $ticket
+	 * @param String $service
+	 * @return array $state
+	 */
+    public function loginCas($ticket, $service) {
+		$login = Cas::authenticate($ticket, $service);
+        if ($login < 0) {
+   			return array("error"=>-1, "error_msg"=>"Erreur de login CAS.");
+        }
+		$this->User = new User($login, 1, "", 0, 1, 0);
+	
+		$r = $this->user->getState();
+		if($r == 405){
+			$this->loginToRegister = $login;
+			return array("error"=>$r, "error_msg"=>"Le user n'existe pas ici.");
+		}
+		elseif($r != 1) {
+			return array("error"=>$r, "error_msg"=>"Le user n'a pas pu être chargé.");
+		}
+		else {
+			return array("success"=>"ok");
+		}
+    }
+
+	/**
+	* Deconnexion (utilisateur)
+	*
+	* @return array $state
+	*/
+	public function logout() {
+		if($this->isLoadedSeller())
+		{
+			unset($this->Seller);
+			session_destroy();
+			return array("success"=>"ok", "url"=>Cas::getUrl()."/logout");
+		} else {
+			return array("error"=>"Aucun seller n'est logué.");
+		}
+	}
+
+
+    /**
+    * Retourne l'url du CAS
+    * @return String $url
+    */
+    public function getCasUrl() {
+        return Cas::getUrl();
+    }
+
+    /**
+     * Verifie qu'un user et/ou une app ont été loggé
+     * Sinon throw une exception 
+     */
+    protected function checkUserApp($user=true, $app=true) {
+        if($user && !$this->user)
+            throw new Exception("Vous devez connecter un utilisateur ! (method loginCas)");
+        if($app && !$this->application)
+            throw new Exception("Vous devez connecter une application ! (method loginApp)");
+    }
+
+    /**
+     * Authentifie une clef d'application
+     */
+    public function loginApp($key) {
+        $service = get_class($this);
+        $application = new Application();
+        $application->from_key($key); // Throw an exception if Application doesn't exists...
+        $this->application = $application;
+        return "ok";
+    }
+    
+    /**
+     * Déconnecte une application
+     */
+     public function logoutApp() {
+        $this->application = null;
+        return "ok";
+     }
+
 
     /**
     * Retourne la véritable IP du client
@@ -64,13 +150,5 @@ class ServiceBase {
         else {
             return "";
         }
-    }
-
-    /**
-    * Retourne l'url du CAS
-    * @return String $url
-    */
-    public function getCasUrl() {
-        return Cas::getUrl();
     }
 }

--- a/class/ServiceBase.class.php
+++ b/class/ServiceBase.class.php
@@ -105,8 +105,15 @@ class ServiceBase {
     * @return array $status
     */
     public function getStatus() {
-        
-        return array("application" => $this->application->to_array(), "user" => $this->user->getNickname());
+        if($this->application)
+            $app = $this->application->to_array();
+        else
+            $app = null;
+        if($this->user)
+            $user = $this->user->getNickname();
+        else
+            $user = null;
+        return array("application" => $app, "user" => $user);
     }
 
     /**

--- a/class/ServiceBase.class.php
+++ b/class/ServiceBase.class.php
@@ -106,7 +106,7 @@ class ServiceBase {
     */
     public function getStatus() {
         
-        return array("application" => $this->application, "user" => $this->user);
+        return array("application" => $this->application->to_array(), "user" => $this->user->getNickname());
     }
 
     /**

--- a/json_dispatcher/services.inc.php
+++ b/json_dispatcher/services.inc.php
@@ -6,4 +6,5 @@ $services = array(
 	'AADMIN' => 'services/AADMIN.service.php',
 	'MADMIN' => 'services/MADMIN.service.php',
 	'STATS' => 'services/STATS.service.php',
+	'KEY' => 'services/KEY.service.php'
 );

--- a/services/KEY.service.php
+++ b/services/KEY.service.php
@@ -44,7 +44,7 @@
 	 */
 	 public function get_current_user_applications() {
         // On a besoin d'avoir un user logged
-        //$this->checkUserApp(true, false);
+        $this->checkUserApp(true, false);
         
 		return "toto";
 	 }

--- a/services/KEY.service.php
+++ b/services/KEY.service.php
@@ -6,6 +6,7 @@
  *
  */
  require_once 'class/Application.class.php';
+ require_once 'class/ApplicationList.class.php';
  require_once 'class/ServiceBase.class.php';
  
  class KEY extends ServiceBase {
@@ -45,8 +46,10 @@
 	 public function get_current_user_applications() {
         // On a besoin d'avoir un user logged
         $this->checkUserApp(true, false);
-        
-		return "toto";
+        $application_list = new ApplicationList();
+        $application_list->from_login($this->user->getNickname());
+        // On retourne la liste d'applications (mais sans la clef, car on ne ne veut pas qu'un service "malintentioné" puisse récupérer les clefs d'un user).
+		return $application_list->to_array($key=0);
 	 }
 	
  }

--- a/services/KEY.service.php
+++ b/services/KEY.service.php
@@ -1,0 +1,49 @@
+<?php 
+/**
+ * KEY.services.php
+ * 
+ * Ce service expose des méthodes pour déclarer des applications 
+ *
+ */
+ require_once 'class/Application.class.php';
+ require_once 'class/ServiceBase.class.php';
+ 
+ class KEY extends ServiceBase {
+	 
+    public function __construct() {
+        parent::__construct();
+    }
+     
+	/**
+	* Enregistre une application
+	* @param array (array containing application information)
+	* @return string la clef
+	*/
+	public function register_application($app_url, $app_name, $app_desc=null) {
+        $this->checkUserApp(true, true);
+		$application = new Application();
+		$application->from_array(Array(
+            "app_id" => null,
+            "app_url" => $app_url,
+            "app_key" => null,
+            "app_name" => $app_name,
+            "app_desc" => $app_desc,
+            "app_creator" => $this->user->getNickname(),
+            "app_lastuse" => null,
+            "app_created" => null
+        ));
+        $application->insert();
+		return $application->to_array();
+	}
+	
+	/**
+	 * Obtenir la liste des applications pour l'user current
+	 * 
+	 * @return Array (liste d'applications)
+	 */
+	 public function get_current_user_applications() {
+        $this->checkUserConnected();
+		return Array("toto");
+	 }
+	
+ }

--- a/services/KEY.service.php
+++ b/services/KEY.service.php
@@ -20,7 +20,8 @@
 	* @return string la clef
 	*/
 	public function register_application($app_url, $app_name, $app_desc=null) {
-        $this->checkUserApp(true, true);
+        // Pour déclarer une nouvelle application on a besoin d'un user, mais pas d'être une application.
+        $this->checkUserApp(true, false);
 		$application = new Application();
 		$application->from_array(Array(
             "app_id" => null,
@@ -42,8 +43,10 @@
 	 * @return Array (liste d'applications)
 	 */
 	 public function get_current_user_applications() {
-        $this->checkUserConnected();
-		return Array("toto");
+        // On a besoin d'avoir un user logged
+        //$this->checkUserApp(true, false);
+        
+		return "toto";
 	 }
 	
  }


### PR DESCRIPTION
Fix #57
Le keymanager est terminé.

Modification apporté =>
Dans ServiceBase:
- Recopie de la méthode loginCas ici
- ajout de la méthode loginApp (pour logger une appli à partir d'une clef)
- ajout d'une méthode générique de déconnexion
  ==> On devrait pouvoir à terme, supprimer le "session_destroy()" si chaque service enfant de ServiceBase étent bien cette fonction pour se réinitialiser comme il le doit.
- ajout d'une méthode "protected" pour permettre au service enfant de vérifier facilement au début d'une méthode, qu'un User et/ou une App est bien authentifié.
  NOTE: Cette méthode devra être étendu, très bientôt pour vérifier que l'app en question à les droits sur le service en question, et que le user en question à les droits sur le service en question (je vais ouvrir un ticket à ce sujet (s'il n'existe pas déjà) et c'est ma prochaine tache.
- ajout d'une méthode "public" getStatus, pour connaitre l'état de la connexion (est ce qu'un service est logé ? et est ce qu'une appli est authentifié ?)

Nouveau service KEY:
- Une fonction pour enregistrer une application (un user doit être authentifié)
  => Attention c'est uniquement à ce moment que la clef sera retourné il ne sera plus possible de la récupérer après. Elle reste secrète.
- Une fonction pour récupérer toutes les applis de l'utilisateurs courant (Sans les clefs, juste les autres infos).

A venir => Ajout d'une méthode pour qu'un user puisse supprimer l'une de ces applications.
