### PR TITLE
Utiliser l'autoloader de Composer

### DIFF
--- a/class/Application.class.php
+++ b/class/Application.class.php
@@ -7,8 +7,6 @@
  */
 
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
 
 class Application {
     protected $db;

--- a/class/ApplicationList.class.php
+++ b/class/ApplicationList.class.php
@@ -7,9 +7,6 @@
  */
 
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
-require_once 'class/Application.class.php';
 
 class ApplicationList {
     protected $db;

--- a/class/Buy.class.php
+++ b/class/Buy.class.php
@@ -28,15 +28,6 @@
  * @package buckutt
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
-require_once 'class/WsdlBase.class.php';
-require_once 'class/Proposition.class.php';
-require_once 'class/Buyer.class.php';
-require_once 'class/Point.class.php';
-require_once 'class/ComplexData.class.php';
-require_once 'class/Price.class.php';
-require_once 'class/Object.class.php';
 
 class Buy extends WsdlBase {
 	

--- a/class/Buyer.class.php
+++ b/class/Buyer.class.php
@@ -30,7 +30,6 @@
 
 //TODO tester dans chaque méthode si state = 1, sinon on poutre
 
-require_once 'class/User.class.php';
 
 class Buyer extends User {
 	

--- a/class/Cas.class.php
+++ b/class/Cas.class.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once 'class/xmlToArrayParser.class.php';
-require_once 'config.inc.php';
 
 class Cas {
 

--- a/class/CheckRight.class.php
+++ b/class/CheckRight.class.php
@@ -9,8 +9,6 @@
  * @package buckutt
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
 
 class CheckRight {
 

--- a/class/FAdminUser.class.php
+++ b/class/FAdminUser.class.php
@@ -28,7 +28,6 @@
  * @version 2.0
  * @package buckutt
  */
-require_once 'class/User.class.php';
 
 class FAdminUser extends User {
 protected $fundation;

--- a/class/Fundation.class.php
+++ b/class/Fundation.class.php
@@ -28,8 +28,6 @@
  * @package buckutt
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
 
 class Fundation {
 

--- a/class/Group.class.php
+++ b/class/Group.class.php
@@ -28,9 +28,6 @@
  * @package buckutt
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
-require_once 'class/Period.class.php';
 
 class Group {
 

--- a/class/Image.class.php
+++ b/class/Image.class.php
@@ -28,8 +28,6 @@
  * @package buckutt
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
 
 class Image
 {

--- a/class/Log.class.php
+++ b/class/Log.class.php
@@ -28,8 +28,6 @@
  * @package buckutt
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
 
 //TODO le truc sql quon a trouvé avec raoul
 class Log

--- a/class/Object.class.php
+++ b/class/Object.class.php
@@ -29,8 +29,6 @@
  * @version 2.0
  * @package buckutt
  */
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
 
 class Object {
 

--- a/class/ObjectWithPrice.class.php
+++ b/class/ObjectWithPrice.class.php
@@ -28,7 +28,6 @@
  * @package buckutt
  */
 
-require_once 'class/Object.class.php';
 
 class ObjectWithPrice extends Object {
 	

--- a/class/Paybox.class.php
+++ b/class/Paybox.class.php
@@ -18,8 +18,6 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-require_once 'config.inc.php';
-require_once 'class/Log.class.php';
 
 class Paybox {
 

--- a/class/Period.class.php
+++ b/class/Period.class.php
@@ -28,8 +28,6 @@
  * @package buckutt
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
 
 class Period {
 

--- a/class/PlageHoraire.class.php
+++ b/class/PlageHoraire.class.php
@@ -9,9 +9,6 @@
  * @package buckutt
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
-require_once 'class/CheckRight.class.php';
 
 class PlageHoraire {
 

--- a/class/Point.class.php
+++ b/class/Point.class.php
@@ -28,8 +28,6 @@
  * @package buckutt
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
 
 class Point {
 

--- a/class/Price.class.php
+++ b/class/Price.class.php
@@ -29,10 +29,6 @@
  * @package buckutt
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
-require_once 'class/Group.class.php';
-require_once 'class/Object.class.php';
 
 class Price {
 	

--- a/class/Proposition.class.php
+++ b/class/Proposition.class.php
@@ -29,11 +29,6 @@
  * @package buckutt
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
-require_once 'class/ObjectWithPrice.class.php';
-require_once 'class/User.class.php';
-require_once 'class/ComplexData.class.php';
 
 class Proposition {
         protected $Seller;

--- a/class/Right.class.php
+++ b/class/Right.class.php
@@ -28,9 +28,6 @@
  * @package buckutt
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
-require_once 'class/Period.class.php';
 
 class Right {
 

--- a/class/Sale.class.php
+++ b/class/Sale.class.php
@@ -29,10 +29,6 @@
  * @package buckutt
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
-require_once 'class/Period.class.php';
-require_once 'class/Object.class.php';
 
 class Sale {
 	

--- a/class/ServiceBase.class.php
+++ b/class/ServiceBase.class.php
@@ -28,15 +28,6 @@
 * @package buckutt
 */
 
-require_once 'config.inc.php';
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
-require_once 'class/Image.class.php';
-require_once 'class/Point.class.php';
-require_once 'class/User.class.php';
-require_once 'class/Cas.class.php';
-require_once 'class/Application.class.php';
-require_once 'class/User.class.php';
 
 class ServiceBase {
     protected $db;

--- a/class/User.class.php
+++ b/class/User.class.php
@@ -30,12 +30,6 @@
 
 //TODO tester dans chaque méthode si state = 1, sinon on poutre
 
-require_once 'class/Group.class.php';
-require_once 'class/Image.class.php';
-require_once 'class/ComplexData.class.php';
-require_once 'class/Log.class.php';
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
 
 /**
  * classe user

--- a/class/WsdlBase.class.php
+++ b/class/WsdlBase.class.php
@@ -28,13 +28,6 @@
  * @package buckutt
  */
 
-require_once 'config.inc.php';
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
-require_once 'class/Image.class.php';
-require_once 'class/Point.class.php';
-require_once 'class/ComplexData.class.php';
-require_once 'class/Cas.class.php';
 
 class WsdlBase {
 	

--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,8 @@
 		"slim/slim": "2.*",
 		"ginger/client": "2.*"
 	},
-    "include-path": ["./"]
+    "include-path": ["./"],
+    "autoload": {
+        "classmap": ["class/", "db/", "services/"]
+    }
 }

--- a/db/Db_buckutt.class.php
+++ b/db/Db_buckutt.class.php
@@ -14,7 +14,6 @@
 	* @license PHP Version 5.0 {@link http://www.php.net/license/5_0.txt}
 	*/
 
-require_once 'config.inc.php';
 
 class Db_buckutt {
 	public $dbType;

--- a/services/AADMIN.service.php
+++ b/services/AADMIN.service.php
@@ -28,15 +28,6 @@
  * @package buckutt
  */
 
-require_once 'config.inc.php';
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
-require_once 'class/Image.class.php';
-require_once 'class/Point.class.php';
-require_once 'class/ComplexData.class.php';
-require_once 'class/Cas.class.php';
-require_once 'class/User.class.php';
-require_once 'class/PlageHoraire.class.php';
 
 // CONSTANTE POUR LES DROITS, A STOCKER DANS UN FICHIER A INCLURE
 	$right_admin = array(1, 2);

--- a/services/KEY.service.php
+++ b/services/KEY.service.php
@@ -5,9 +5,6 @@
  * Ce service expose des méthodes pour déclarer des applications 
  *
  */
- require_once 'class/Application.class.php';
- require_once 'class/ApplicationList.class.php';
- require_once 'class/ServiceBase.class.php';
  
  class KEY extends ServiceBase {
 	 

--- a/services/MADMIN.service.php
+++ b/services/MADMIN.service.php
@@ -28,16 +28,6 @@
  * @package payutc
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
-require_once 'class/WsdlBase.class.php';
-require_once 'class/Buyer.class.php';
-require_once 'class/User.class.php';
-require_once 'class/ComplexData.class.php';
-require_once 'class/Paybox.class.php';
-require_once 'class/Cas.class.php';
-require_once 'config.inc.php';
-require_once 'class/Log.class.php';
 
 class MADMIN extends WsdlBase {
 

--- a/services/POSS2-with-exceptions.service.php
+++ b/services/POSS2-with-exceptions.service.php
@@ -1,6 +1,5 @@
 <?php 
 
-require_once 'services/POSS2.service.php';
 
 class PossException extends Exception {
 	public $err_code;

--- a/services/POSS2.service.php
+++ b/services/POSS2.service.php
@@ -29,15 +29,6 @@
  * @package buckutt
  */
 
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
-require_once 'class/Buy.class.php';
-require_once 'class/Point.class.php';
-require_once 'class/Seller.class.php';
-require_once 'class/Buyer.class.php';
-require_once 'class/Log.class.php';
-require_once 'class/Cas.class.php';
-require_once 'class/CheckRight.class.php';
 
 define('MEAN_OF_LOGIN_BADGE', 5);
 define('MEAN_OF_LOGIN_NICKNAME', 1);

--- a/services/STATS.service.php
+++ b/services/STATS.service.php
@@ -28,15 +28,6 @@
  * @package buckutt
  */
 
-require_once 'config.inc.php';
-require_once 'db/Db_buckutt.class.php';
-require_once 'db/Mysql.class.php';
-require_once 'class/Image.class.php';
-require_once 'class/Point.class.php';
-require_once 'class/ComplexData.class.php';
-require_once 'class/Cas.class.php';
-require_once 'class/User.class.php';
-require_once 'class/PlageHoraire.class.php';
 
 
 class STATS {


### PR DESCRIPTION
Tous les require peuvent maintenant être retirés (mais je pense en avoir fait une bonne partie :smiley:).

Needless to say : `php composer.phar update`

**/!\ Les classes de payutc n'étant pas PSR-0, il faut refaire `php composer.phar update` si on en ajoute/supprime pour que Composer mette à jour l'autoloader.**
