### PR TITLE
Support de l'autoloader dans Db_Buckutt

### DIFF
--- a/db/Db_buckutt.class.php
+++ b/db/Db_buckutt.class.php
@@ -35,12 +35,10 @@ class Db_buckutt {
 
 	public final function  __construct ($type) {
 		$this->type = $type;
-		if(class_exists(strtolower($type))){
-			$this->dbType = new $type();
-			return true;
-		}else{
-			return false;
-		}
+
+        $this->dbType = new $type();
+
+		return true;
 	}
     
     /**
@@ -52,7 +50,7 @@ class Db_buckutt {
 		global $_CONFIG;
         if (! isset (self::$instance))
         {
-            self::$instance = new Db_buckutt('mysql');
+            self::$instance = new Db_buckutt('Mysql');
             self::$instance->connect($_CONFIG['sql_host'], $_CONFIG['sql_db'], $_CONFIG['sql_user'], $_CONFIG['sql_pass']);
         }
         return self::$instance;


### PR DESCRIPTION
class_exists renvoie faux en fait si la fonction n'a jamais été appelée.

Je ne teste plus l'existence, mais de toute façon le constructeur est toujours appelé par le `getInstance` et la classe `Db_buckutt` va bientôt être deprecated (#66).
