### PR TITLE
Fix success result handler in POSS2WithException

### DIFF
--- a/services/POSS2-with-exceptions.service.php
+++ b/services/POSS2-with-exceptions.service.php
@@ -28,8 +28,11 @@ class POSS2WithExceptions extends POSS2
 			$error_msg = $r["error_msg"];
 			throw new PossException($error, $error_msg);
 		}
+		else if (is_array($r) and array_key_exists("success", $r)) {
+				return $r["success"];
+		}
 		else {
-			return $r["success"];
+				return $r;
 		}
 	}
 	


### PR DESCRIPTION
handle no-array success returns on POSS2WithExceptions
