### PR TITLE
Reduce $_CONFIG usage in background classes

### DIFF
--- a/class/Cas.class.php
+++ b/class/Cas.class.php
@@ -2,10 +2,9 @@
 
 
 class Cas {
-
-	public static function authenticate($ticket,$service) {
+	public static function authenticate($ticket, $service, $cas_url) {
 		global $_CONFIG;
-		$url_validate = $_CONFIG['cas_url']."serviceValidate?service=".$service."&ticket=".$ticket;
+		$url_validate = $cas_url."serviceValidate?service=".$service."&ticket=".$ticket;
 		$data = file_get_contents($url_validate);
 		if(empty($data)) return -1;
 		
@@ -15,10 +14,4 @@ class Cas {
 		else
 			return -1;
 	}
-	
-	public static function getURl() {
-		global $_CONFIG;
-		return $_CONFIG['cas_url'];
-	}
-	
 }

--- a/class/ServiceBase.class.php
+++ b/class/ServiceBase.class.php
@@ -50,7 +50,8 @@ class ServiceBase {
 	 * @return array $state
 	 */
     public function loginCas($ticket, $service) {
-		$login = Cas::authenticate($ticket, $service);
+        global $_CONFIG;
+		$login = Cas::authenticate($ticket, $service, $_CONFIG['cas_url']);
         if ($login < 0) {
    			return array("error"=> array( "message"=>"Erreur de login cas", "code" => -1));
         }
@@ -89,7 +90,8 @@ class ServiceBase {
     * @return String $url
     */
     public function getCasUrl() {
-        return Cas::getUrl();
+        global $_CONFIG;
+        return $_CONFIG['cas_url'];
     }
 
     /**

--- a/class/WsdlBase.class.php
+++ b/class/WsdlBase.class.php
@@ -50,7 +50,8 @@ class WsdlBase {
 	 * @return String $url
 	 */
 	public function getCasUrl() {
-	 return Cas::getUrl();
+	 global $_CONFIG;
+	 return $_CONFIG['cas_url'];
 	}
 	
 	/**

--- a/src/Payutc/Dispatcher/Soap.php
+++ b/src/Payutc/Dispatcher/Soap.php
@@ -32,19 +32,24 @@
 namespace Payutc\Dispatcher;
 
 class Soap {
+    protected $server_url;
+    protected $wsdl_cache;
+    
+    public __construct($server_url, $wsdl_cache) {
+        $this->server_url = $server_url;
+    }
     public function handle($name_class){
-        global $_CONFIG;
         $app = \Slim\Slim::getInstance();
         
         \Payutc\Mapping\Services::checkExist($name_class);
         
         if (isset($_GET['wsdl'])) {
             $server = new \Zend\Soap\AutoDiscover();
-            $server->setUri($_CONFIG['server_url'].$name_class.'.class.php');
+            $server->setUri($this->server_url.$name_class.'.class.php');
             $server->setClass("Payutc\\Service\\$name_class");
             echo $server->toXml();
         } else {
-            $server = new \Zend\Soap\Server($_CONFIG['server_url'].$name_class.'.class.php?wsdl', array('cache_wsdl' => $_CONFIG['wsdl_cache']));
+            $server = new \Zend\Soap\Server($this->server_url.$name_class.'.class.php?wsdl', array('cache_wsdl' => $this->wsdl_cache));
             $server->setClass("Payutc\\Service\\$name_class");
             $server->setPersistence(SOAP_PERSISTENCE_SESSION);
             $server->handle();

--- a/src/Payutc/Log.php
+++ b/src/Payutc/Log.php
@@ -4,10 +4,9 @@ namespace Payutc;
 
 class Log
 {
-    public static function initLog()
+    public static function initLog($slimSettings = array())
     {
         global $_SERVER;
-        global $_CONFIG;
         
         if (!isset($_SERVER['REQUEST_METHOD'])) $_SERVER['REQUEST_METHOD'] = null;
         if (!isset($_SERVER['REMOTE_ADDR'])) $_SERVER['REMOTE_ADDR'] = null;
@@ -19,8 +18,7 @@ class Log
         
         $app = \Slim\Slim::getInstance();
         if ($app === null) {
-            $userSettings = $_CONFIG['slim_config'];
-            $app = new \Slim\Slim($userSettings);
+            $app = new \Slim\Slim($slimSettings);
         }
     }
     

--- a/src/Payutc/Service/AADMIN.php
+++ b/src/Payutc/Service/AADMIN.php
@@ -65,7 +65,8 @@ class AADMIN {
 	 * @return String $url
 	 */
 	public function getCasUrl() {
-	 return Cas::getUrl();
+	 global $_CONFIG;
+	 return $_CONFIG['cas_url'];
 	}
 
 
@@ -93,7 +94,8 @@ class AADMIN {
 	 * @return int $state
 	 */
     public function loginCas($ticket, $service) {
-		$login = Cas::authenticate($ticket, $service);
+		global $_CONFIG;
+		$login = Cas::authenticate($ticket, $service, $_CONFIG['cas_url']);
 		if ($login < 0) {
 			return -1;
 		}

--- a/src/Payutc/Service/MADMIN.php
+++ b/src/Payutc/Service/MADMIN.php
@@ -59,7 +59,8 @@ class MADMIN extends \WsdlBase {
      * @return array $state
      */
     public function loginCas($ticket, $service) {
-        $login = Cas::authenticate($ticket, $service);
+        global $_CONFIG;
+        $login = Cas::authenticate($ticket, $service, $_CONFIG['cas_url']);
         if ($login < 0) {
                return array("error"=>-1, "error_msg"=>"Erreur de login CAS.");
         }
@@ -357,12 +358,21 @@ WHERE osr_login = '%s'", Array($this->loginToRegister));
      */
      
     public function reload($amount, $callbackUrl) {
+        global $_CONFIG;
               // Peut-il se recharger d'un tel montant
               $auth = $this->canReload($amount);
               if($auth != 1)
                     return "<error>".$this->getErrorDetail($auth)."</error>";
 
-        $pb = new Paybox($this->User);
+        $pb = new Paybox(
+            $this->User,
+            $_CONFIG['PBX_EXE'],
+            $_CONFIG['PBX_SITE'],
+            $_CONFIG['PBX_RANG'],
+            $_CONFIG['PBX_IDENTIFIANT'],
+            $_CONFIG['http_server_url']."/payboxretour.php",
+            $_CONFIG['proxy']
+        );
         return $pb->execute($amount, $callbackUrl);
     }
     

--- a/src/Payutc/Service/POSS2.php
+++ b/src/Payutc/Service/POSS2.php
@@ -49,6 +49,7 @@ class POSS2 {
 	protected $Fun_id;
 
 	protected function getRemoteIp() {
+		global $_SERVER;
 		return $_SERVER['REMOTE_ADDR'];
 	}
 
@@ -57,7 +58,8 @@ class POSS2 {
 	 * @return array $url
 	 */
 	public function getCasUrl() {
-	 return array("success"=>Cas::getUrl());
+	 global $_CONFIG;
+	 return array("success"=>$_CONFIG['cas_url']);
 	}
 
 	/**
@@ -70,9 +72,10 @@ class POSS2 {
 	 * @return array $state
 	*/
 	public function loadPos($ticket, $service, $poi_id, $fun_id) {
+		global $_CONFIG;
 		unset($this->Seller);
 		$ip = $this->getRemoteIp();
-		$login = Cas::authenticate($ticket, $service);
+		$login = Cas::authenticate($ticket, $service, $_CONFIG['cas_url']);
 		if ($login < 0) {
 			return array("error"=>-1, "error_msg"=>"Erreur de login CAS.");
 		}
@@ -101,11 +104,12 @@ class POSS2 {
 	* @return array $state
 	*/
 	public function logout() {
+		global $_CONFIG;
 		if($this->isLoadedSeller())
 		{
 			unset($this->Seller);
 			session_destroy();
-			return array("success"=>"ok", "url"=>Cas::getUrl()."/logout");
+			return array("success"=>"ok", "url"=>$_CONFIG['cas_url']."/logout");
 		} else {
 			return array("error"=>"1401", "error_msg"=>"Aucun seller n'est logué.");
 		}

--- a/tests/LogTest.php
+++ b/tests/LogTest.php
@@ -1,7 +1,6 @@
 <?php
 
 require_once '../vendor/autoload.php';
-require_once '../config.inc.php';
 
 
 class MyWriter
@@ -32,11 +31,13 @@ class LogTest extends PHPUnit_Framework_TestCase
 	
 	public function __construct()
 	{
-		global $_CONFIG;
+		$config = array(
+			'log.writer' => new MyWriter(),
+			'log.level' => \Slim\Log::DEBUG,
+			'log.enabled' => true
+		);
 		
-		$_CONFIG['slim_config']['log.writer'] = new MyWriter();
-		$_CONFIG['slim_config']['log.level'] = \Slim\Log::DEBUG;
-		$_CONFIG['slim_config']['log.enabled'] = true;
+		Log::initLog($config);
 	}
 	
 	protected function setUp()
@@ -49,14 +50,6 @@ class LogTest extends PHPUnit_Framework_TestCase
 		Log::getWriter()->clean();
 	}
 	
-	public function testInitDontCrash()
-	{
-		Log::initLog();
-	}
-	
-	/**
-	 * @depends testInitDontCrash
-	 */
 	public function testGetInstance()
 	{
 		$this->assertTrue(Log::getInstance() !== null);

--- a/web/index.php
+++ b/web/index.php
@@ -19,8 +19,9 @@ $app->map('/:service/:method', function($service, $method) use ($app) {
 })->via('GET', 'POST');
 
 // SOAP route
-$app->map('/:service.class.php', function($service) {
-    $dispatcher = new \Payutc\Dispatcher\Soap();
+$server_url = $_CONFIG['server_url'];
+$app->map('/:service.class.php', function($service) use $server_url{
+    $dispatcher = new \Payutc\Dispatcher\Soap($server_url);
     $dispatcher->handle($service);
 })->via('GET', 'POST');
 

--- a/web/payboxretour.php
+++ b/web/payboxretour.php
@@ -4,4 +4,4 @@ require_once '../vendor/autoload.php';
 require_once '../config.inc.php';
 
 require_once 'class/Paybox.class.php';
-Paybox::PBXretour();
+Paybox::PBXretour($_CONFIG['PBX_PUBPEM']);


### PR DESCRIPTION
Linked to #134 

Je trouve qu'on utilise trop `global $_CONFIG` partout, je propose d'interdire son usage en dehors des services, et même eux ils devraient prendre un array config plutôt que d'utiliser `global $_CONFIG`.

Faites vos remarques.
