### PR TITLE
checkRight accepte desormais de checker les 'superadmins'

### DIFF
--- a/class/ApplicationRight.class.php
+++ b/class/ApplicationRight.class.php
@@ -19,22 +19,28 @@ class ApplicationRight {
      * Verifie un tuple de droits.
      * Lorsque les droits n'existe pas throw an exception
      */
-	public static function check($application_id = false, $service_name = false, $fundation_id = false) {
+	public static function check($application_id = false, $service_name = false, $check_fundation = false, $fundation_id = NULL) {
         $db = Db_buckutt::getInstance();
         $req = "SELECT afu.afu_id FROM tj_app_fun_afu afu 
                             WHERE afu.app_id = '%u' 
                             AND (afu.afu_service = '%s' OR afu.afu_service = 'ALL')
                             AND afu.afu_removed IS NULL ";
-        if($fundation_id)
-            $res = $db->query($req." AND (afu.fun_id = '%u' OR afu.fun_id IS NULL)", array($application_id, $service_name, $fundation_id));
-        else
+
+        if($check_fundation) {
+            if($fundation_id) {
+                $res = $db->query($req." AND (afu.fun_id = '%u' OR afu.fun_id IS NULL)", array($application_id, $service_name, $fundation_id));
+            } else {
+                $res = $db->query($req." AND afu.fun_id IS NULL", array($application_id, $service_name)); 
+            }
+        } else {
             $res = $db->query($req, array($application_id, $service_name));
+        }
 
 		if ($db->affectedRows() == 0) {
             if($fundation_id)
-	            throw new \Exception("L'application_id $application_id n'a pas les droits $service_name sur la fundation n°$fundation_id");
+	            throw new \Payutc\Exception\CheckRightException("L'application_id $application_id n'a pas les droits $service_name sur la fundation n°$fundation_id");
             else
-                throw new \Exception("L'application_id $application_id n'a les droits $service_name sur aucune fundation");
+                throw new \Payutc\Exception\CheckRightException("L'application_id $application_id n'a les droits $service_name sur aucune fundation");
 	    }
         return true;
     }

--- a/class/ServiceBase.class.php
+++ b/class/ServiceBase.class.php
@@ -180,7 +180,7 @@ class ServiceBase {
         try {
             $this->checkRight(true, true, true, NULL);
             return true;
-        } catch (\Payutc\Exception\CheckRightException) {
+        } catch (\Payutc\Exception\CheckRightException $e) {
             return false;
         }
     }

--- a/class/ServiceBase.class.php
+++ b/class/ServiceBase.class.php
@@ -172,6 +172,18 @@ class ServiceBase {
         }
         return true;
     }
+    
+    /*
+     * Return true if current user is admin (=> Have right on this service with fun_id = NULL)
+     */
+    public function isAdmin() {
+        try {
+            $this->checkRight(true, true, true, NULL);
+            return true;
+        } catch (\Payutc\Exception\CheckRightException) {
+            return false;
+        }
+    }
 
     /**
      * Retourne les fundations sur les quels on a les droits pour travailer

--- a/class/ServiceBase.class.php
+++ b/class/ServiceBase.class.php
@@ -147,28 +147,27 @@ class ServiceBase {
      * Si votre fonction est ouverte à tout le monde, ne rien mette ou mettre: $this->checkRight(false, false) sera équivalent.
      * 
      * Lorsque votre fonction travaille sur une fundation, vous devez passer $fun_check à true pour indiquer que vous tenez à la verification des droits sur le fun_id
-     * et bien sur fun_id == NULL sera refusé
+     * et bien sur fun_id == NULL ne sera authorisé que si l'utilisateur est "super admin" sur le droit en question.
      */
     public function checkRight($user=true, $app=true, $fun_check=false, $fun_id=NULL) {
-        if($fun_id == NULL && $fun_check == true) {
-            throw new Exception("fun_id cannot be 'NULL' !");
-        }
         if($user)
         {
             if(!$this->user)
-                throw new Exception("Vous devez connecter un utilisateur ! (method loginCas)");
+                throw new \Payutc\Exception\CheckRightException("Vous devez connecter un utilisateur ! (method loginCas)");
             // Check if App_id <=> Fun_id <=> Service_name exists in ApplicationRight
             UserRight::check($this->user->getId(),
                              $this->service_name,
+                             $fun_check,
                              $fun_id);
         }
         if($app)
         {
             if(!$this->application)
-                throw new Exception("Vous devez connecter une application ! (method loginApp)");
+                throw new \Payutc\Exception\CheckRightException("Vous devez connecter une application ! (method loginApp)");
             // Check if App_id <=> Fun_id <=> Service_name exists in ApplicationRight
             ApplicationRight::check($this->application->getId(),
                                     $this->service_name,
+                                    $fun_check,
                                     $fun_id);
         }
         return true;
@@ -267,7 +266,9 @@ class ServiceBase {
             try {
                 $this->checkRight();
                 $result[] = $service;            
-            } catch(\Exception $e) { /* no right for this service */ }
+            } 
+            catch(\Payutc\Exception\CheckRightException $e) { /* no right for this service */ }
+            catch(\Exception $e) { throw $e; }
         }
         // put back the correct $this->service_name
         $this->service_name = end(explode("\\", get_class($this)));

--- a/class/ServiceBase.class.php
+++ b/class/ServiceBase.class.php
@@ -268,7 +268,6 @@ class ServiceBase {
                 $result[] = $service;            
             } 
             catch(\Payutc\Exception\CheckRightException $e) { /* no right for this service */ }
-            catch(\Exception $e) { throw $e; }
         }
         // put back the correct $this->service_name
         $this->service_name = end(explode("\\", get_class($this)));

--- a/class/UserRight.class.php
+++ b/class/UserRight.class.php
@@ -18,21 +18,28 @@ class UserRight {
      * Verifie un tuple de droits.
      * Lorsque les droits n'existe pas throw an exception
      */
-	public static function check($user_id = false, $service_name = false, $fundation_id = false) {
+	public static function check($user_id = false, $service_name = false, $check_fundation = false, $fundation_id = NULL) {
         $db = Db_buckutt::getInstance();
         $req = "SELECT ufu.ufu_id FROM tj_usr_fun_ufu ufu 
                                 WHERE ufu.usr_id = '%u' 
                                 AND (ufu.ufu_service = '%s' OR ufu.ufu_service = 'ALL') 
                                 AND ufu.ufu_removed IS NULL ";
-        if($fundation_id)
-            $res = $db->query($req." AND (ufu.fun_id = '%u' OR ufu.fun_id IS NULL)", array($user_id, $service_name, $fundation_id));
-        else
+
+        if($check_fundation) {
+            if($fundation_id) {
+                $res = $db->query($req." AND (ufu.fun_id = '%u' OR ufu.fun_id IS NULL)", array($user_id, $service_name, $fundation_id));
+            } else {
+                $res = $db->query($req." AND ufu.fun_id IS NULL", array($user_id, $service_name)); 
+            }
+        } else {
             $res = $db->query($req, array($user_id, $service_name));
+        }
+        
 		if ($db->affectedRows() == 0) {
             if($fundation_id)
-	            throw new \Exception("Le user_id $user_id n'a pas les droits $service_name sur la fundation n°$fundation_id");
+	            throw new \Payutc\Exception\CheckRightException("Le user_id $user_id n'a pas les droits $service_name sur la fundation n°$fundation_id");
             else
-                throw new \Exception("Le user_id $user_id n'a les droits $service_name sur aucune fundation");
+                throw new \Payutc\Exception\CheckRightException("Le user_id $user_id n'a les droits $service_name sur aucune fundation");
 	    }
         return true;
     }

--- a/src/Payutc/Exception/CheckRightException.php
+++ b/src/Payutc/Exception/CheckRightException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Payutc\Exception;
+
+class CheckRightException extends \Exception {}

--- a/src/Payutc/Mapping/Errors.php
+++ b/src/Payutc/Mapping/Errors.php
@@ -10,14 +10,15 @@ class Errors {
             'Payutc\Exception\ServiceMethodForbidden' => 403,
             'Payutc\Exception\ServiceMissingMethodArgument' => 400,
             'PossException' => '\Payutc\Mapping\Errors::defaultHandler',
-            'Payutc\Exception\UserIsBlockedException' => '\Payutc\Mapping\Errors::defaultHandler'
+            'Payutc\Exception\UserIsBlockedException' => '\Payutc\Mapping\Errors::defaultHandler',
+            'Payutc\Exception\CheckRightException' => '\Payutc\Mapping\Errors::defaultHandler'
         );
     }
     
     public static function defaultHandler(\Exception $e)
     {
 		return array(
-        			'type' => 'PossException', 
+        			'type' => 'PayutcException', 
         			'code' => $e->getCode(), 
         			'message' => $e->getMessage()
         );


### PR DESCRIPTION
Les 'superadmins' sont des gens qui ont des droits sur toutes les fundations. (`fun_id = NULL`)

Il peut être utile dans certain cas de checker qu'ils ont ce droit.
Par exemple, dans le cas du service ADMINRIGHT, on peut vouloir donner au personnes qui ont le super-droit, de pouvoir ajouter une application sur toutes les fundations.

Ou la possibilité pour un 'superadmin' de donner les droits à son (ses successeurs) et supprimer les droits à ces prédécesseurs...
