### PR TITLE
Correction des build des erreurs travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - mysql -e 'create database buckutt_test;'
   - mysql -u root buckutt_test < dev_structure.sql
   - curl -s https://getcomposer.org/installer | php
-  - php composer.phar install --dev --no-interaction
+  - php composer.phar install --dev --prefer-source --no-interaction
   - cd tests/
   - mkdir logs
   - chmod 777 logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - mysql -e 'create database buckutt_test;'
   - mysql -u root buckutt_test < dev_structure.sql
   - curl -s https://getcomposer.org/installer | php
-  - php composer.phar install --dev
+  - php composer.phar install --dev --no-interaction
   - cd tests/
   - mkdir logs
   - chmod 777 logs


### PR DESCRIPTION
Selon https://github.com/composer/composer/issues/1314, le fait de
rajouter ce paramètre permet d'éviter les erreurs dûes aux limitations de
l'API.
