### PR TITLE
usr_credit n'est plus unsigned dans la db

### DIFF
--- a/dev_structure.sql
+++ b/dev_structure.sql
@@ -202,7 +202,7 @@ CREATE TABLE IF NOT EXISTS `ts_user_usr` (
   `usr_nickname` varchar(200) COLLATE utf8_general_ci DEFAULT NULL COMMENT 'Surnom',
   `usr_adult` int(1) DEFAULT NULL,
   `usr_mail` varchar(200) COLLATE utf8_general_ci DEFAULT NULL COMMENT 'Adresse mail de l''utilisateur',
-  `usr_credit` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Crédit',
+  `usr_credit` smallint(6) NOT NULL DEFAULT '0' COMMENT 'Crédit',
   `img_id` int(11) unsigned DEFAULT NULL COMMENT 'Identifiant de l''image',
   `usr_temporary` tinyint(1) unsigned NOT NULL DEFAULT '0' COMMENT '1 s''il s''agit d''un utilisateur temporaire',
   `usr_fail_auth` tinyint(1) unsigned NOT NULL DEFAULT '0' COMMENT 'Nombre d''échec d''authentification depuis la dernière réussite',


### PR DESCRIPTION
Suite au bug de mise en production de la derniere release, certain rechargement ont eu lieu alors qu'il n'aurait pas du.

La solution la plus simple pour remettre la situation en place, consiste à placer les personnes qui n'ont plus assez d'argent pour rembourser le "déficit" en négatif.

Cette PR, ne change rien au fait que payutc est codé de tel sorte que personne ne puisse s'attribuer le droit d'aller en négatif. C'est exceptionnel quelques comptes vont être en négatif, mais dès lors qu'ils seront revenus positifs ils ne pourront pas redevenir négatifs et tant que leur solde sera négatif ils ne pourront rien faire à part recharger (pas de virement, pas d'achat...)
