### PR TITLE
Forcer Slim en 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "slim/slim": "2.*",
+        "slim/slim": "2.2.*",
         "slim/extras": "*",
         "ginger/client": "2.*",
         "zendframework/zendframework": "2.*",


### PR DESCRIPTION
Mesure temporaire pour avoir un dépôt stable et réparer Travis
car il y a un problème avec le logger depuis la sortie de Slim 2.3

J'ai créé #228 pour le suivi de la mise à jour de Slim
