### PR TITLE
Remplir les  nouvelles colonnes lors de la migration "quantités"

### DIFF
--- a/src/Payutc/Migrations/Version20130829233731.php
+++ b/src/Payutc/Migrations/Version20130829233731.php
@@ -12,6 +12,7 @@ class Version20130829233731 extends AbstractMigration
         $this->addSql("ALTER TABLE `t_purchase_pur`
           ADD `pur_qte` INT UNSIGNED NOT NULL DEFAULT '1' COMMENT 'Nombre d''object acheté' AFTER `obj_id` ,
           ADD `pur_unit_price` INT UNSIGNED NOT NULL COMMENT 'Prix unitaire de l''object acheté' AFTER `pur_qte`");
+        $this->addSql("UPDATE `t_purchase_pur` SET `pur_unit_price` = `pur_price`, pur_qte = 1 WHERE pur_unit_price = 0");
     }
 
     public function down(Schema $schema)


### PR DESCRIPTION
Histoire de ne pas se retrouver avec une colonne pur_unit_price à 0
