### PR TITLE
Add date & qte fields to purchases

### DIFF
--- a/src/Payutc/Bom/Purchase.php
+++ b/src/Payutc/Bom/Purchase.php
@@ -191,7 +191,7 @@ class Purchase
     public static function getPurchasesForUser($usr_id, $time_limit=null)
     {
         $qb = Dbal::createQueryBuilder();
-        $qb->select('pur_id', 'obj_id', 'pur_price')
+        $qb->select('pur_id', 'obj_id', 'pur_price', 'pur_qte', 'pur_date')
            ->from('t_purchase_pur', 'pur')
            ->Where('usr_id_buyer = :usr_id')
            ->andWhere('pur_removed = 0')

--- a/src/Payutc/Bom/User.php
+++ b/src/Payutc/Bom/User.php
@@ -316,10 +316,10 @@ class User {
     *
     * @return array $return
     */
-    public function getLastPurchase() {
+    public function getLastPurchases() {
         return Purchase::getPurchasesForUser($this->getId(), 60*15);
     }
-
+    
     /**
     * Initialiser ginger, éventuellement avec une URL perso
     *

--- a/src/Payutc/Service/POSS2.php
+++ b/src/Payutc/Service/POSS2.php
@@ -233,7 +233,7 @@ ORDER BY obj_name;", array($right_POI_FUNDATION, $this->Point_id, $this->Fun_id)
 										"firstname"=>$buyer->getFirstname(), 
 										"lastname"=>$buyer->getLastname(), 
 										"solde"=>$buyer->getCredit(),
-										"last_purchase"=>$buyer->getLastPurchase()
+										"last_purchase"=>$buyer->getLastPurchases()
 								));
 		} else {
 			Log::warn("getBuyerInfo() : No Seller loaded");

--- a/src/Payutc/Service/POSS3.php
+++ b/src/Payutc/Service/POSS3.php
@@ -44,7 +44,7 @@ class POSS3 extends \ServiceBase {
             "firstname"=>$buyer->getFirstname(), 
             "lastname"=>$buyer->getLastname(), 
             "solde"=>$buyer->getCredit(),
-            "last_purchases"=>$buyer->getLastPurchase()
+            "last_purchases"=>$buyer->getLastPurchases()
         );
     }
     

--- a/tests/Payutc/Service/Poss3RodbTest.php
+++ b/tests/Payutc/Service/Poss3RodbTest.php
@@ -83,7 +83,7 @@ class Poss3RodbTest extends ServiceBaseRodbTest
     {
         $u = new User("trecouvr");
         $solde = $u->getCredit();
-        $nb_purchase = count($u->getLastPurchase());
+        $nb_purchase = count($u->getLastPurchases());
         $cookie = '';
         $r = httpSend('POSS3', 'loginCas', $cookie, array(
             'ticket' => 'trecouvr@POSS3',

--- a/tests/Payutc/Service/Poss3RwdbTest.php
+++ b/tests/Payutc/Service/Poss3RwdbTest.php
@@ -29,7 +29,7 @@ class Poss3RwdbTest extends DatabaseTest
     {
         $u = new User("trecouvr");
         $solde = $u->getCredit();
-        $nb_purchase = count($u->getLastPurchase());
+        $nb_purchase = count($u->getLastPurchases());
         $cookie = '';
         $r = httpSend('POSS3', 'loginCas', $cookie, array(
             'ticket' => 'trecouvr@POSS3',
@@ -55,7 +55,7 @@ class Poss3RwdbTest extends DatabaseTest
         $this->assertEquals(200, $r->code);
         $u = new User("trecouvr");
         $this->assertEquals($solde-280, $u->getCredit());
-        $purchases = $u->getLastPurchase();
+        $purchases = $u->getLastPurchases();
         sort_by_key($purchases, 'pur_id');
         $this->assertEquals($nb_purchase+3, count($purchases));
         $purchases = array_slice($purchases, count($purchases)-3);
@@ -74,7 +74,7 @@ class Poss3RwdbTest extends DatabaseTest
     {
         $u = new User("trecouvr");
         $solde = $u->getCredit();
-        $nb_purchase = count($u->getLastPurchase());
+        $nb_purchase = count($u->getLastPurchases());
         $cookie = '';
         $r = httpSend('POSS3', 'loginCas', $cookie, array(
             'ticket' => 'trecouvr@POSS3',

--- a/tests/PurchaseRodbTest.php
+++ b/tests/PurchaseRodbTest.php
@@ -73,6 +73,17 @@ class PurchaseRodbTest extends ReadOnlyDatabaseTest
         $this->assertEquals($waited,$r);
 
     }
+    
+    public function testGetPurchasesForUser() {
+        $purchases = Purchase::getPurchasesForUser(9447);
+        $this->assertTrue(count($purchases) > 0);
+        $pur = $purchases[0];
+        $this->assertArrayHasKey('pur_id', $pur);
+        $this->assertArrayHasKey('obj_id', $pur);
+        $this->assertArrayHasKey('pur_price', $pur);
+        $this->assertArrayHasKey('pur_qte', $pur);
+        $this->assertArrayHasKey('pur_date', $pur);
+    }
 }
 
 


### PR DESCRIPTION
Fix #156
- add date & qte fields to purchases of Purchase$getPurchasesForUser return
- rename User$getLastPurchase into User$getLastPurchases
