### PR TITLE
Retrait de l'import de l'ancien solde

### DIFF
--- a/dev_data.sql
+++ b/dev_data.sql
@@ -187,10 +187,3 @@ INSERT INTO `tj_usr_rig_jur` (`jur_id`, `usr_id`, `rig_id`, `per_id`, `fun_id`, 
 (21, NULL, 7, NULL, 2, 46, 0),
 (27, 9447, 5, NULL, 2, NULL, 0);
 
-
---
--- Contenu de la table `t_oldusr_osr`
---
-
-INSERT INTO `t_oldusr_osr` (`osr_login`, `osr_credit`, `osr_date`) VALUES
-('puyouart', 465, '2012-06-15 20:46:45');

--- a/src/Payutc/Migrations/Version20130930144743.php
+++ b/src/Payutc/Migrations/Version20130930144743.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Payutc\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+    Doctrine\DBAL\Schema\Schema;
+
+class Version20130930144743 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql("DROP TABLE `t_oldusr_osr`");
+    }
+
+    public function down(Schema $schema)
+    {
+      $this->addSql("CREATE TABLE IF NOT EXISTS `t_oldusr_osr` (
+        `osr_login` varchar(255) CHARACTER SET latin1 DEFAULT NULL,
+        `osr_credit` float DEFAULT NULL,
+        `osr_date` datetime DEFAULT NULL,
+        UNIQUE KEY `osr_login` (`osr_login`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;");
+    }
+}

--- a/src/Payutc/Service/MADMIN.php
+++ b/src/Payutc/Service/MADMIN.php
@@ -136,25 +136,9 @@ class MADMIN {
             // This is normal, it's even what we want
         }
         
-        // On récupére l'ancien solde
-        $res = $this->db->query("SELECT osr_credit
-FROM `t_oldusr_osr` 
-WHERE osr_login = '%s'", Array($this->loginToRegister));
-        $solde = 0;
-        if ($this->db->affectedRows() >= 1) {
-            while ($don = $this->db->fetchArray($res)) {
-                $solde = $don['osr_credit'];
-            }
-        }
-
         // On créé le user et on lui ajoute son crédit
         try {
             $this->User = User::createAndGetNewUser($this->loginToRegister);
-            if($solde > 0){
-                $this->User->incCredit($solde);
-                $userid = $this->User->getId();        
-                $this->db->query("INSERT INTO t_recharge_rec (rty_id, usr_id_buyer, usr_id_operator, poi_id, rec_date, rec_credit, rec_trace) VALUES ('%u', '%u', '%u', '%u', NOW(), '%u', '%s')", array(7, $userid, $userid, 1, $solde, "Import ancien solde"));                
-            }
         }
         catch (\Exception $ex){
             Log::error("Impossible de créer le user $this->loginToRegister: ".$ex->getMessage());


### PR DESCRIPTION
On arrête les imports d'anciens soldes, ce PR retire le code qui gérait ça et supprime la table correspondante.
