### PR TITLE
Migrations pour les tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_script:
   - curl -s https://getcomposer.org/installer | php
   - php composer.phar install --dev --prefer-source --no-interaction
   - mysql -e 'create database buckutt_test;'
-  - php db.php migrations:migrate --no-interaction
 script: ./tests/run_all.sh
 
 

--- a/tests/start_server.sh
+++ b/tests/start_server.sh
@@ -21,6 +21,12 @@ fi
 echo "Copy test config"
 cp config.inc.php ../
 
+echo "Migrating database structure"
+pushd ..
+php db.php migrations:migrate --no-interaction
+echo "If migrations failed, you should probably empty your test database"
+popd
+
 echo "Get faux-ginger"
 if [ -d faux-ginger ]
 then

--- a/tests/start_server.sh
+++ b/tests/start_server.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-PHPVER=`echo "<?php echo PHP_VERSION_ID;" | php`
-if [ "$PHPVER" -lt 50400 ]
-then
-    echo "PHP version < 5.4.0, skipping"
-    exit 0
-fi
-
 cd `dirname $0`
 
 FAUX_GINGER_PORT=33434
@@ -26,6 +19,13 @@ pushd ..
 php db.php migrations:migrate --no-interaction
 echo "If migrations failed, you should probably empty your test database"
 popd
+
+PHPVER=`echo "<?php echo PHP_VERSION_ID;" | php`
+if [ "$PHPVER" -lt 50400 ]
+then
+    echo "PHP version < 5.4.0, skipping"
+    exit 0
+fi
 
 echo "Get faux-ginger"
 if [ -d faux-ginger ]

--- a/tests/stop_server.sh
+++ b/tests/stop_server.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-PHPVER=`echo "<?php echo PHP_VERSION_ID;" | php`
-if [ "$PHPVER" -lt 50400 ]
-then
-    echo "PHP version < 5.4.0, skipping"
-    exit 0
-fi
-
 cd `dirname $0`
 
 echo "Put back initial environment"
@@ -15,5 +8,13 @@ then
     rm ../config.inc.php
     mv config.inc.php.bak ../config.inc.php
 fi
+
+PHPVER=`echo "<?php echo PHP_VERSION_ID;" | php`
+if [ "$PHPVER" -lt 50400 ]
+then
+    echo "PHP version < 5.4.0, skipping"
+    exit 0
+fi
+
 echo "Killing php servers"
 ps x | grep -v grep | grep "php -S localhost:" | awk '{print $1}' | xargs kill


### PR DESCRIPTION
Déplacement de la migration au début des tests de travis vers start_server.sh pour que la base de données de tests soit mise à jour lorsque les tests sont lancés en local.
