### PR TITLE
Retourner le nom de la fondation avec les infos du vendeur

### DIFF
--- a/src/Payutc/Service/POSS2.php
+++ b/src/Payutc/Service/POSS2.php
@@ -146,6 +146,11 @@ class POSS2 {
 	public function getSellerIdentity() {
 		if ($this->isLoadedSeller()) {
 			$identity = $this->Seller->getIdentity();
+			
+			$res = DbBuckutt::getInstance()->query("SELECT fun_name FROM t_fundation_fun WHERE fun_id = '%u';", array($this->Fun_id));
+			$fundation = DbBuckutt::getInstance()->fetchArray($res);
+			$identity['fun_name'] = $fundation['fun_name'];
+			
 			return array("success"=>$identity);
 		} else {
 			Log::warn("getSellerIdentity() : No Seller loaded");


### PR DESCRIPTION
On a besoin du nom de la fondation dans le mozart actuel rapidement (c'est un truc temporaire tant qu'on utilise encore POSS2).
