### PR TITLE
Utiliser une requête préparée pour le blocage

### DIFF
--- a/src/Payutc/Bom/User.php
+++ b/src/Payutc/Bom/User.php
@@ -272,9 +272,10 @@ class User {
         
         $qb = Dbal::createQueryBuilder();
         $qb->update('ts_user_usr', 'usr')
-            ->set('usr_blocked', $qb->expr()->literal($blocage))
+            ->set('usr_blocked', ':usr_blocked')
             ->where('usr_id = :usr_id')
-            ->setParameter('usr_id', $this->idUser);
+            ->setParameter('usr_id', $this->idUser, "integer")
+            ->setParameter('usr_blocked', $blocage, "integer");
         
         $affectedRows = $qb->execute();
         if ($affectedRows != 1){


### PR DESCRIPTION
Même si ici il y avait une fonction pour quote, il vaut mieux utiliser des requêtes préparées (en spécifiant les types) pour toutes les données arrivant de l'extérieur.
