### PR TITLE
Modification du .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,4 @@
 /tests/config.inc.php
 /tests/faux-cas
 /tests/faux-ginger
-/log*.txt
-/tests/log*.txt
-
+/tests/logs


### PR DESCRIPTION
D'après les config .dist, les fichiers de log sont dans un dossier logs/, à la racine pour le dev et dans tests/ pour les tests. Si vous avez des fichiers de log ailleurs, vérifiez que config.inc.php (pour dev et pour tests) est à jour.
