### PR TITLE
Mettre le buyer à null lors d'une transaction CB

### DIFF
--- a/src/Payutc/Bom/Transaction.php
+++ b/src/Payutc/Bom/Transaction.php
@@ -124,7 +124,12 @@ class Transaction {
     }
     
     public function setBuyer($buyer){
-        $this->buyerId = $buyer->getId();
+        if($buyer == null){
+            $this->buyerId = null;
+        }
+        else {
+            $this->buyerId = $buyer->getId();
+        }
         
         Dbal::conn()->update('t_transaction_tra',
             array('usr_id_buyer' => $this->buyerId),

--- a/src/Payutc/Service/WEBSALECONFIRM.php
+++ b/src/Payutc/Service/WEBSALECONFIRM.php
@@ -111,6 +111,7 @@ class WEBSALECONFIRM extends \ServiceBase {
             }
         } else {
             $pl = new Payline($this->application()->getId(), $this->service_name);
+            $transaction->setBuyer(null);
             return $pl->doWebPayment(
                 null, 
                 $transaction, 

--- a/tests/TransactionRwdbTest.php
+++ b/tests/TransactionRwdbTest.php
@@ -135,5 +135,23 @@ class TransactionRwdbTest extends DatabaseTest
         $transaction2 = Transaction::getById($transaction->getId());
         $this->assertEquals("arthur@puyou.fr", $transaction2->getEmail());
     }
+    
+	/**
+     * @requires PHP 5.4
+	 */    
+    public function testSetToNull(){
+        $items = array(
+            array(4, 1),
+            array(4, 3)
+        );
+        $matthieu = new User("mguffroy");
+        $transaction = Transaction::create($matthieu, $matthieu, 51, 1, $items, null, null);
+
+        $this->assertEquals(600, $transaction->getMontantTotal());
+        
+        $transaction->setBuyer(null);
+        
+        $this->assertEquals(null, $transaction->getBuyerId());
+    }
 }
 


### PR DESCRIPTION
Si l'utilisateur essaie de payer par compte payutc, que ça échoue, puis paie par CB, on veut effacer le buyerId pour pouvoir distinguer le type de transaction.
