### PR TITLE
Allow only POST on services

### DIFF
--- a/src/Payutc/WebApp.php
+++ b/src/Payutc/WebApp.php
@@ -13,7 +13,7 @@ class WebApp {
         
         $app = new \Slim\Slim(\Payutc\Config::get('slim_config'));
         // JSON route
-        $app->map('/:service/:method', function($service, $method) use ($app) {
+        $app->post('/:service/:method', function($service, $method) use ($app) {
             $dispatcher = new \Payutc\Dispatcher\Json();
 
             // JSON Error handler


### PR DESCRIPTION
Allowing GET may lead to a security break in the future.

JsonClient uses by default POST, AutoJsonClient uses only POST. Scoobydoo and Casper both use AutoJsonClient, so no modification need to be done to them.
