### PR TITLE
Diminution des appels à payline

### DIFF
--- a/src/Payutc/Bom/Payline.php
+++ b/src/Payutc/Bom/Payline.php
@@ -215,18 +215,18 @@ class Payline {
             $return_url = "";
         }
         
+        if($result['pay_step'] != "W") {
+            // ERROR ! Ce rechargement n'est pas en attente.
+            // Tentative de double rechargement ?
+            Log::warn("PAYLINE : Notification sur une transaction qui n'est pas en attente.", array('token' => $token));
+            return $return_url;
+        }
+        
         $response = $this->payline->getWebPaymentDetails($array);
         if(isset($response)){
             // Paiement valide
             if($response["result"]["code"] == "00000") {
                 $conn = Dbal::conn();
-
-                if($result['pay_step'] != "W") {
-                    // ERROR ! Ce rechargement n'est pas en attente.
-                    // Tentative de double rechargement ?
-                    Log::warn("PAYLINE : Tentative de double rechargement !", array('token' => $token, 'response'=>$response));
-                    return $return_url;
-                }
                 
                 $conn->beginTransaction();
                 try {

--- a/src/Payutc/Bom/Payline.php
+++ b/src/Payutc/Bom/Payline.php
@@ -218,7 +218,7 @@ class Payline {
         if($result['pay_step'] != "W") {
             // ERROR ! Ce rechargement n'est pas en attente.
             // Tentative de double rechargement ?
-            Log::warn("PAYLINE : Notification sur une transaction qui n'est pas en attente.", array('token' => $token));
+            Log::warn("PAYLINE : Notification sur une transaction qui n'est pas en attente", array('token' => $token));
             return $return_url;
         }
         

--- a/tests/Payutc/Bom/PaylineRwdbTest.php
+++ b/tests/Payutc/Bom/PaylineRwdbTest.php
@@ -304,7 +304,7 @@ class PaylineRwdbTest extends DatabaseTest
         $this->fakeSdk->validate($token);
         $this->payline->notification($token);
         $this->payline->notification($token);
-        $s = 'PAYLINE : Tentative de double rechargement !';
+        $s = "PAYLINE : Notification sur une transaction qui n'est pas en attente";
         $this->assertTrue($this->strIsInLogs($s));
     }
     


### PR DESCRIPTION
Ce test peut être réalisé avant d'appeler payline. A priori 50% des appels payline, finissent dans cet état, donc on va grandement y gagner.
