### PR TITLE
Gestion des réductions

### DIFF
--- a/src/Payutc/Bom/Transaction.php
+++ b/src/Payutc/Bom/Transaction.php
@@ -374,7 +374,7 @@ class Transaction {
                         Log::warn("transaction() : Invalid reduction for article $object[0]", compact('funId', 'appId',
                                                                                                     'buyer', 'seller',
                                                                                                       'object'));
-                        throw new PossException("La réduction pour l'article $object[0] est invalide.");
+                        throw new InvalidReduction("La réduction pour l'article $object[0] est invalide.");
                     } else {
                         $reduction = $object[2];
                         $price = round($price * (1 - $reduction));

--- a/src/Payutc/Bom/Transaction.php
+++ b/src/Payutc/Bom/Transaction.php
@@ -370,12 +370,14 @@ class Transaction {
                 $price = $product['price'] * $object[1];
                 // Apply the reduction
                 if(isset($object[2]) && !is_null($object[2])) {
-                    if ($object[2] <= 0 || $object[2] >= 1) {
-                        Log::warn("transaction($funId, $transactionId) : Invalid reduction $object[2] for article $object[0]");
-                        throw new InvalidReduction("La réduction pour l'article $object[0] est invalide.");
+                    if ($object[2] < 0 || $object[2] > 1) {
+                        Log::warn("transaction() : Invalid reduction for article $object[0]", compact('funId', 'appId',
+                                                                                                    'buyer', 'seller',
+                                                                                                      'object'));
+                        throw new PossException("La réduction pour l'article $object[0] est invalide.");
                     } else {
                         $reduction = $object[2];
-                        $price = $price * (1 - $reduction);
+                        $price = round($price * (1 - $reduction));
                     }
                 } else {
                     $reduction = null;

--- a/src/Payutc/Exception/InvalidReduction.php
+++ b/src/Payutc/Exception/InvalidReduction.php
@@ -1,0 +1,3 @@
+<?php namespace Payutc\Exception;
+
+class InvalidReduction extends PayutcException {}

--- a/src/Payutc/Migrations/Version20131126235734.php
+++ b/src/Payutc/Migrations/Version20131126235734.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Payutc\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+    Doctrine\DBAL\Schema\Schema;
+
+class Version20131126235734 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql("ALTER TABLE `t_purchase_pur`
+ADD `pur_reduction` FLOAT NULL DEFAULT NULL AFTER `pur_unit_price`");
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql("ALTER TABLE `t_purchase_pur`
+DROP `pur_reduction`;");
+    }
+}

--- a/src/Payutc/Service/POSS3.php
+++ b/src/Payutc/Service/POSS3.php
@@ -123,8 +123,8 @@ class POSS3 extends \ServiceBase {
         }
 
         // tranformer la chaine passee en un array exploitable
-        // il y a deux formats : ids séparés par des espaces (pas de quantités) ou json
-        // $objects est un array de array($idProduct, $qte)
+        // il y a deux formats : ids séparés par des espaces (pas de quantités) ou json array d'arrays (id_product, qte, %reduction)
+        // $objects est un array de array($idProduct, $qte, $reduc)
         $objects = json_decode($obj_ids);
         Log::debug('decoded objects', array('objects' => $objects));
         
@@ -132,7 +132,7 @@ class POSS3 extends \ServiceBase {
             $objects_ids = explode(" ", trim($obj_ids));
             $objects = array();
             foreach ($objects_ids as $id) {
-                $objects[] = array($id, 1);
+                $objects[] = array($id, 1, null);
             }
         }
 

--- a/tests/Payutc/Bom/TransactionRwdbTest.php
+++ b/tests/Payutc/Bom/TransactionRwdbTest.php
@@ -81,8 +81,8 @@ class TransactionRwdbTest extends DatabaseTest
 	 */
     public function testCreateAndValidate(){
         $items = array(
-            array(5, 1),
-            array(5, 1)
+            array(5, 1, null),
+            array(5, 1, 0.1)
         );
 
         $matthieu = new User("mguffroy");
@@ -91,13 +91,35 @@ class TransactionRwdbTest extends DatabaseTest
         $this->assertEquals('V', $transaction->getStatus());
 
         $u = new User("mguffroy");
-        $this->assertEquals(4660, $u->getCredit());
+        $this->assertEquals(4677, $u->getCredit());
 
         $p = Product::getOne(5,1);
         $this->assertEquals(40, $p['stock']);
 
         $r = Purchase::getNbSell(5, 1);
         $this->assertEquals(4, $r);
+    }
+
+	/**
+     * @requires PHP 5.4
+     * @expectedException         \Payutc\Exception\InvalidReduction
+	 */
+    public function testIllegalReduction(){
+        $items = array(array(5, 1, 0));
+
+        $matthieu = new User("mguffroy");
+        $transaction = Transaction::createAndValidate($matthieu, $matthieu, 51, 1, $items, null, null);
+    }
+
+	/**
+     * @requires PHP 5.4
+     * @expectedException         \Payutc\Exception\InvalidReduction
+	 */
+    public function testIllegalReduction2(){
+        $items = array(array(5, 1, 1));
+
+        $matthieu = new User("mguffroy");
+        $transaction = Transaction::createAndValidate($matthieu, $matthieu, 51, 1, $items, null, null);
     }
     
 	/**

--- a/tests/Payutc/Bom/TransactionRwdbTest.php
+++ b/tests/Payutc/Bom/TransactionRwdbTest.php
@@ -104,8 +104,8 @@ class TransactionRwdbTest extends DatabaseTest
      * @requires PHP 5.4
      * @expectedException         \Payutc\Exception\InvalidReduction
 	 */
-    public function testIllegalReduction(){
-        $items = array(array(5, 1, 0));
+    public function testIllegalReductionSup(){
+        $items = array(array(5, 1, 1.01));
 
         $matthieu = new User("mguffroy");
         $transaction = Transaction::createAndValidate($matthieu, $matthieu, 51, 1, $items, null, null);
@@ -115,8 +115,8 @@ class TransactionRwdbTest extends DatabaseTest
      * @requires PHP 5.4
      * @expectedException         \Payutc\Exception\InvalidReduction
 	 */
-    public function testIllegalReduction2(){
-        $items = array(array(5, 1, 1));
+    public function testIllegalReductionInf(){
+        $items = array(array(5, 1, -0.2));
 
         $matthieu = new User("mguffroy");
         $transaction = Transaction::createAndValidate($matthieu, $matthieu, 51, 1, $items, null, null);

--- a/tests/Payutc/Service/Poss3RwdbTest.php
+++ b/tests/Payutc/Service/Poss3RwdbTest.php
@@ -70,6 +70,69 @@ class Poss3RwdbTest extends DatabaseTest
     /**
      * @requires PHP 5.4
      */
+    public function testTransactionWithQuanityAndReductions()
+    {
+        $u = new User("trecouvr");
+        $solde = $u->getCredit();
+        $nb_purchase = count($u->getLastPurchases());
+        $cookie = '';
+        $r = httpSend('POSS3', 'loginCas', $cookie, array(
+            'ticket' => 'trecouvr@POSS3',
+            'service' => 'POSS3'
+        ));
+        $this->assertEquals(200, $r->code);
+        $r = httpSend('POSS3', 'loginApp', $cookie, array(
+                                                          'key' => 'my_app'
+                                                          ));
+        $this->assertEquals(200, $r->code);
+
+        $objects = array(array(1, 1, null), // pas de réduction
+                         array(2, 2), // réduction non précisée
+                         array(1, 2, 0.1), // 10% de reduction
+                         array(2, 2, 0.03), // 3%, pour tester l'arrondi inf
+                         array(3, 1, 0.03), // 3%, pour tester l'arrondi sup
+                         );
+        /* soit un prix de 1€ + 1,6€ + 2€ * (1-0,1) + 1,6€ * (1-0,03) *
+         * 1,7€ * (1-0,03) = 7,601€
+         * Mais le système doit arrondir à 7,60€ parcequ'on ne peut pas enlever de montant inférieur au centime
+         */
+
+        $r = httpSend('POSS3', 'transaction', $cookie, array(
+            'fun_id' => 1,
+            'badge_id' => 'ABCDABCD',
+            'obj_ids' => json_encode($objects)
+            ));
+        $o = array(
+                   'firstname' => 'Thomas',
+                   'lastname' => 'Recouvreux',
+                   'solde' => $solde-760,
+                   'msg_perso' => 'http://payutc.github.io'
+                   );
+        $this->assertEquals($o, $r->body);
+        $this->assertEquals(200, $r->code);
+        $u = new User("trecouvr");
+        $this->assertEquals($solde-760, $u->getCredit());
+        $purchases = $u->getLastPurchases();
+        sort_by_key($purchases, 'pur_id');
+        $this->assertEquals($nb_purchase+count($objects), count($purchases));
+        $purchases = array_slice($purchases, count($purchases)-count($objects));
+        // obj ids
+        $this->assertEquals(1, $purchases[0]['obj_id']);
+        $this->assertEquals(2, $purchases[1]['obj_id']);
+        $this->assertEquals(1, $purchases[2]['obj_id']);
+        $this->assertEquals(2, $purchases[3]['obj_id']);
+        $this->assertEquals(3, $purchases[4]['obj_id']);
+        // total price
+        $this->assertEquals(100, $purchases[0]['pur_price']);
+        $this->assertEquals(160, $purchases[1]['pur_price']);
+        $this->assertEquals(180, $purchases[2]['pur_price']);
+        $this->assertEquals(155, $purchases[3]['pur_price']);
+        $this->assertEquals(165, $purchases[4]['pur_price']);
+    }
+
+    /**
+     * @requires PHP 5.4
+     */
     public function testCancel()
     {
         $u = new User("trecouvr");

--- a/tests/Payutc/Service/Poss3RwdbTest.php
+++ b/tests/Payutc/Service/Poss3RwdbTest.php
@@ -94,7 +94,9 @@ class Poss3RwdbTest extends DatabaseTest
                          );
         /* soit un prix de 1€ + 1,6€ + 2€ * (1-0,1) + 1,6€ * (1-0,03) *
          * 1,7€ * (1-0,03) = 7,601€
-         * Mais le système doit arrondir à 7,60€ parcequ'on ne peut pas enlever de montant inférieur au centime
+         * Chaque ligne est arrondie à l'entier le plus proche puisqu'on ne
+         *  peut pas débiter de montant inférieur au centime
+         * Dans le cas de ce test ça fait 7,60€
          */
 
         $r = httpSend('POSS3', 'transaction', $cookie, array(


### PR DESCRIPTION
Normalement la compatibilité n'est pas cassée, si on ne précise pas de réduction on considère que c'est un null.
La réduction se met après la quantité : null pour pas de réduction ou un nombre dans ]0, 1[ pour une réduction.
