### PR TITLE
Payline PRODUCTION constant was not set

### DIFF
--- a/src/Payutc/Bom/Payline.php
+++ b/src/Payutc/Bom/Payline.php
@@ -52,6 +52,8 @@ if (!defined('__PAYUTC_PAYLINE_OPTIONS')) {
     define('INI_FILE' , __DIR__ . '/../../../vendor/payline/HighDefinition.ini'); // Chemin du fichier ini
     define('PAYLINE_ERR_TOKEN', '02317,02318'); // Préfixe du token sur le site primaire
     define('__PAYUTC_PAYLINE_OPTIONS', '__PAYUTC_PAYLINE_OPTIONS');
+    
+    define('PRODUCTION', Config::get('payline_production'));
 }
 
 


### PR DESCRIPTION
La constante `PRODUCTION` est utilisé dans payline mais on ne la définit pas.

Je propose donc de la rajouter... 

https://github.com/payutc/server/blob/master/vendor/payline/Payline/paylineSDK.php#L755

PS: Une autre option consiste à transformer la ligne 755 de paylineSDK pour la faire faire matcher la ligne 740 (https://github.com/payutc/server/blob/master/vendor/payline/Payline/paylineSDK.php#L740)

Option 1 ou Option 2 ?
