### PR TITLE
Correction de l’implémentation des blocages (notamment les dates)

### DIFF
--- a/src/Payutc/Bom/Blocked.php
+++ b/src/Payutc/Bom/Blocked.php
@@ -90,7 +90,7 @@ class Blocked {
         $req   .= ")";
         $db->query($req, $insert_data);
         if ($db->affectedRows() != 1) {
-			throw new Exception("Une erreur s'est produite lors du blocage de l'utilisateur.");
+			throw new \Exception("Une erreur s'est produite lors du blocage de l'utilisateur.");
 		}
         return $db->insertId();
     }
@@ -157,14 +157,15 @@ WHERE blo.usr_id = usr.usr_id ";
             $req .= "blo_removed = '%s' ";
             $param[] = $fin->format("Y-m-d H:i:s");
         }
-        $req .= " WHERE blo_id = '%u' AND (blo_removed < NOW() OR blo_removed IS NULL) ";
+        $req .= " WHERE blo_id = '%u' AND (blo_removed > NOW() OR blo_removed IS NULL) ";
         $param[] = $blo_id;
         if($fun_id != NULL) {
             $req .= " AND fun_id = '%u' ";
             $param[] = $fun_id;
         }
-        //return $req." ".print_r($param, true);
+
         $db->query($req, $param);
+
         if ($db->affectedRows() != 1) {
 			throw new \Exception("Une erreur s'est produite lors de l'edition du blocage utilisateur.");
 		}

--- a/src/Payutc/Service/BLOCKED.php
+++ b/src/Payutc/Service/BLOCKED.php
@@ -32,14 +32,14 @@ class BLOCKED extends \ServiceBase {
 
         if ($date_fin != NULL) {
             $date_fin = \DateTime::createFromFormat("Y-m-d H:i:s", $date_fin);
-            if ($date_fin == False) {
+            if ($date_fin == false) {
                 throw new InvalidData("Format de date de début incorrect");
             }
         }
 
         if ($date_debut != NULL) {
             $date_debut = \DateTime::createFromFormat("Y-m-d H:i:s", $date_debut);
-            if ($date_debut == False) {
+            if ($date_debut == false) {
                 throw new InvalidData("Format de date de fin incorrect");
             }
         }
@@ -55,7 +55,7 @@ class BLOCKED extends \ServiceBase {
 
         if ($date_fin != NULL) {
             $date_fin = \DateTime::createFromFormat("Y-m-d H:i:s", $date_fin);
-            if ($date_fin == False) {
+            if ($date_fin == false) {
                 throw new InvalidData("Format de date de fin incorrect");
             }
         }

--- a/src/Payutc/Service/BLOCKED.php
+++ b/src/Payutc/Service/BLOCKED.php
@@ -1,6 +1,7 @@
 <?php 
 
 namespace Payutc\Service;
+use \Payutc\Exception\InvalidData;
 
 /**
  * BLOCKED.services.php
@@ -28,6 +29,21 @@ class BLOCKED extends \ServiceBase {
      */
     public function block($usr_id, $fun_id, $raison, $date_fin=NULL, $date_debut=NULL) {
         $this->checkRight(true, true, true, $fun_id);
+
+        if ($date_fin != NULL) {
+            $date_fin = \DateTime::createFromFormat("Y-m-d H:i:s", $date_fin);
+            if ($date_fin == False) {
+                throw new InvalidData("Format de date de début incorrect");
+            }
+        }
+
+        if ($date_debut != NULL) {
+            $date_debut = \DateTime::createFromFormat("Y-m-d H:i:s", $date_debut);
+            if ($date_debut == False) {
+                throw new InvalidData("Format de date de fin incorrect");
+            }
+        }
+        
         return \Payutc\Bom\Blocked::block($usr_id, $fun_id, $raison, $date_fin, $date_debut);
     }
      
@@ -36,6 +52,14 @@ class BLOCKED extends \ServiceBase {
       */
     public function edit($blo_id, $fun_id, $raison=NULL, $date_fin=NULL) {
         $this->checkRight(true, true, true, $fun_id);
+
+        if ($date_fin != NULL) {
+            $date_fin = \DateTime::createFromFormat("Y-m-d H:i:s", $date_fin);
+            if ($date_fin == False) {
+                throw new InvalidData("Format de date de fin incorrect");
+            }
+        }
+        
         return \Payutc\Bom\Blocked::edit($blo_id, $fun_id, $raison, $date_fin);
     }
 

--- a/tests/Payutc/Bom/BlockedRwdbTest.php
+++ b/tests/Payutc/Bom/BlockedRwdbTest.php
@@ -1,0 +1,42 @@
+<?php
+
+require_once 'utils.php';
+
+use \Payutc\Bom\Blocked;
+
+class BlockedRwdbTest extends DatabaseTest
+{
+
+    public function getDataSet()
+    {
+        return $this->computeDataSet(array(
+            'blocked',           
+        ));
+    }
+
+
+    /**
+	 * Test whether a user can be blocked with start and end dates
+	 * 
+	 * @expectedException		 \Payutc\Exception\UserIsBlockedException
+	 * @expectedExceptionMessage L'utilisateur à été bloqué pour le motif suivant: A piqué dans la caisse
+	 */
+    public function testCreateBlo()
+    {
+        Blocked::block(5, 1, "A piqué dans la caisse", new \DateTime("2050-01-01 00:00:00"), new \DateTime("2000-01-01 00:00:00"));
+        Blocked::checkUsrNotBlocked(5, 1);
+    }
+
+    /**
+	 * Test whether a block can be edited
+	 * 
+	 * @expectedException		 \Payutc\Exception\UserIsBlockedException
+	 * @expectedExceptionMessage L'utilisateur à été bloqué pour le motif suivant: Changement de message
+	 */
+    public function testEditBlo()
+    {
+        Blocked::edit(2, 2, "Changement de message", new \DateTime("2050-01-01 00:00:00"));
+        Blocked::checkUsrNotBlocked(5, 2);
+    }
+}
+

--- a/tests/Payutc/Bom/UserRodbTest.php
+++ b/tests/Payutc/Bom/UserRodbTest.php
@@ -12,7 +12,8 @@ class UserRodbTest extends ReadOnlyDatabaseTest
 	public function getDataSet()
 	{
         return $this->computeDataset(array(
-            'users'
+            'users',
+            'blocked',
         ));
 	}
 	

--- a/tests/seed/blocked.php
+++ b/tests/seed/blocked.php
@@ -10,5 +10,13 @@ $data = array (
       'blo_raison' => 'A fait pipi sur le mur, vilain pas beau !',
       'blo_insert' => '2000-01-01',
     ),
+    1 => 
+    array (
+      'blo_id' => 2,
+      'usr_id' => 5,
+      'fun_id' => 2,
+      'blo_raison' => 'Test',
+      'blo_insert' => '2010-01-01',
+    ),
   ),
 );

--- a/tests/seed/users.php
+++ b/tests/seed/users.php
@@ -44,6 +44,14 @@ $data = array (
     ),
     4 => 
     array (
+      'usr_id' => 5,
+      'usr_firstname' => 'Test',
+      'usr_lastname' => 'Bloqué',
+      'usr_nickname' => 'tbloque',
+      'usr_credit' => 7500,
+    ),
+    5 => 
+    array (
       'usr_id' => 9447,
       'usr_firstname' => 'Matthieu',
       'usr_lastname' => 'Guffroy',


### PR DESCRIPTION
Je suis en train de mettre au point un client vente + admin pour le Fablab et j’ai remarqué que les dates de début et de fin n’ont jamais été utilisées pour les blocages, hors de petits bugs empêchaient leur utilisation.
