### PR TITLE
Ajout du mail sur le retour de WEBSALE/getTransactionInfo

### DIFF
--- a/src/Payutc/Service/WEBSALE.php
+++ b/src/Payutc/Service/WEBSALE.php
@@ -89,7 +89,8 @@ class WEBSALE extends \ServiceBase {
             "id" => $tra_id,
             "status" => $transaction->getStatus(),
             "purchases" => $transaction->getPurchases(),
-            "created" => $transaction->getDate()
+            "created" => $transaction->getDate(),
+            "email" => $transaction->getEmail()
         );
     }
  }


### PR DESCRIPTION
De manière à pouvoir sécuriser le client, github.com/simde-utc/bdecotiz, j'ai besoin de récupérer l'adresse mail que j'ai indiqué au moment de créer la transaction.
