### PR TITLE
Correction de l'utilisation de $gingerUser dans User::__contruct

### DIFF
--- a/src/Payutc/Bom/User.php
+++ b/src/Payutc/Bom/User.php
@@ -56,6 +56,7 @@ class User {
     * @param string $username Login of the User object to init
     */
     public function __construct($username, $gingerUser = null) {
+        $this->gingerUser = $gingerUser;
         Log::debug("User: __construct($username, [gingerUser])", array('ginger_user' => $gingerUser));
         
         $query = Dbal::createQueryBuilder()


### PR DESCRIPTION
Sinon passer ce paramètre ne sert à rien
Il est en fait utilisé pour ne pas faire deux requêtes de suite à ginger (fonctions User::getUserFromBadge et User::createAndGetNewUser)
