### PR TITLE
Modification de la politique de gestion des non cotisants

### DIFF
--- a/src/Payutc/Bom/Product.php
+++ b/src/Payutc/Bom/Product.php
@@ -25,7 +25,8 @@ class Product {
             "price"=>$don['pri_credit'],
             "tva"=>$don['pri_tva'],
             "alcool"=>$don['obj_alcool'],
-            "image"=>$don['img_id']
+            "image"=>$don['img_id'],
+            "cotisant"=>$don['obj_cotisant']
         );
     } 
 
@@ -45,7 +46,7 @@ class Product {
         
         $qb = Dbal::createQueryBuilder();
         $qb->select('itm.obj_id', 'itm.obj_name', 'oli.obj_id_parent', 
-                    'itm.fun_id', 'itm.obj_stock', 'itm.obj_alcool', 
+                    'itm.fun_id', 'itm.obj_stock', 'itm.obj_alcool', 'itm.obj_cotisant', 
                     'pri.pri_credit', 'pri.pri_tva', 'itm.img_id')
             ->from('t_object_obj', 'itm')
             ->leftjoin('itm', 't_price_pri', 'pri', 'pri.obj_id = itm.obj_id')
@@ -80,7 +81,7 @@ class Product {
     public static function getOne($obj_id, $fun_id=null, $removed=0) {
         $qb = Dbal::createQueryBuilder();
         $qb->select('obj.obj_id', 'obj.obj_name', 'oli.obj_id_parent', 'obj.fun_id', 
-                    'obj.obj_stock', 'obj.obj_alcool', 'pri.pri_credit', 'pri.pri_tva', 'obj.img_id')
+                    'obj.obj_stock', 'obj.obj_alcool', 'obj.obj_cotisant', 'pri.pri_credit', 'pri.pri_tva', 'obj.img_id')
            ->from('t_object_obj', 'obj')
            ->leftjoin('obj', 'tj_object_link_oli', 'oli', 'oli.obj_id_child = obj.obj_id')
            ->leftjoin('obj', 't_price_pri', 'pri', 'pri.obj_id = obj.obj_id')
@@ -117,9 +118,10 @@ class Product {
     * @param int $image
     * @param int $fun_id
     * @param $tva
+    * @param $cotisant
     * @return array $categorie
     */
-    public static function add($nom, $parent, $prix, $stock, $alcool, $image, $fun_id, $tva) {
+    public static function add($nom, $parent, $prix, $stock, $alcool, $image, $fun_id, $tva, $cotisant) {
         $conn = Dbal::conn();
         $db = DbBuckutt::getInstance();
         // 1. Verification que le parent existe (et qu'il est bien dans la fundation indiqué (vu qu'on a vérifié les droits grâce à ça)
@@ -135,9 +137,9 @@ class Product {
 
             $article_id = $db->insertId(
               $db->query(
-                  "INSERT INTO t_object_obj (`obj_id`, `obj_name`, `obj_type`, `obj_stock`, `obj_single`, `img_id`, `fun_id`, `obj_removed`, `obj_alcool`)
-                  VALUES (NULL, '%s', 'product', '%d', '0',  %s, '%u', '0', '%u');",
-                  array($nom, $stock, $image, $fun_id, $alcool)));
+                  "INSERT INTO t_object_obj (`obj_id`, `obj_name`, `obj_type`, `obj_stock`, `obj_single`, `img_id`, `fun_id`, `obj_removed`, `obj_alcool`, `obj_cotisant`)
+                  VALUES (NULL, '%s', 'product', '%d', '0',  %s, '%u', '0', '%u', '%u');",
+                  array($nom, $stock, $image, $fun_id, $alcool, $cotisant)));
 
             // 3. CREATION DU LIEN SUR LE PARENT
             $db->query(
@@ -172,9 +174,10 @@ class Product {
     * @param int $image 0 pour conserver la valeur actuelle, -1 pour la supprimer, id dans la table image sinon
     * @param int $fun_id
     * @param int $tva
+    * @param int $cotisant
     * @return array $categorie
     */
-    public static function edit($id, $nom, $parent, $prix, $stock, $alcool, $image, $fun_id, $tva) {
+    public static function edit($id, $nom, $parent, $prix, $stock, $alcool, $image, $fun_id, $tva, $cotisant) {
         $qb = Dbal::createQueryBuilder();
         $db = DbBuckutt::getInstance();
         // 1. GET THE ARTICLE
@@ -247,13 +250,13 @@ class Product {
             $qb->execute();
         }
 
-        // 6. EDIT THE ARTICLE NAME AND STOCK
+        // 6. EDIT THE ARTICLE NAME AND STOCK AND cotisant
         if($image == 0) {
           $image = "`img_id`";
         } else if ($image == -1) {
           $image = "NULL";
         }
-        $db->query("UPDATE t_object_obj SET  `obj_name` =  '%s', `obj_stock` = '%d', `obj_alcool` = '%u', `img_id` = %s WHERE `obj_id` = '%u';",array($nom, $stock, $alcool, $image, $id));
+        $db->query("UPDATE t_object_obj SET  `obj_name` =  '%s', `obj_stock` = '%d', `obj_alcool` = '%u', `img_id` = %s, `obj_cotisant` = '%u' WHERE `obj_id` = '%u';",array($nom, $stock, $alcool, $image, $cotisant, $id));
 
         return array("success"=>$id);
     }

--- a/src/Payutc/Bom/Transaction.php
+++ b/src/Payutc/Bom/Transaction.php
@@ -346,7 +346,7 @@ class Transaction {
         $items = array();
         foreach($products as $item) {
             $items[$item['id']] = $item;
-            if($item->cotisant) {
+            if($item['cotisant']) {
                 $forceCotisant = true;
             }
         }

--- a/src/Payutc/Bom/Transaction.php
+++ b/src/Payutc/Bom/Transaction.php
@@ -339,11 +339,26 @@ class Transaction {
         $products = Product::getAll(array('itm_ids' => array_unique($objectsIds), 'fun_ids' => array($funId)));
         
         // Index the products by their ID
+
+        // check if there is a "forceCotisant" product
+        $forceCotisant = false;
+
         $items = array();
         foreach($products as $item) {
             $items[$item['id']] = $item;
+            if($item->cotisant) {
+                $forceCotisant = true;
+            }
         }
         
+        // If there is a "forceCotisant" product, and a buyer (the check is not done for online payment)
+        // we check that buyer is really cotisant, if no we throw an exception the transaction is not possible
+        if($buyer && $forceCotisant) {
+            if(!$buyer->isCotisant()) {
+                throw new PossException($buyer->getNickname()." n'est pas cotisant, et au moins l'un des articles sélectionés n'est pas ouvert à la vente pour les non cotisants.");
+            }
+        }
+
         try {
             $conn->beginTransaction();
             

--- a/src/Payutc/Bom/User.php
+++ b/src/Payutc/Bom/User.php
@@ -419,7 +419,7 @@ class User {
      */
     public function transfer($amount, $userID, $message="") {
         $message = htmlspecialchars($message);
-        if(!$this->user()->isCotisant()) {
+        if(!$this->isCotisant()) {
             throw new TransferException("Les non cotisants ne peuvent pas utiliser la fonction virement.");
         } else if($amount < 0) {
             Log::warn("TRANSFERT: Montant négatif par l'userID ".$this->getId()." vers l'user ".$userID);

--- a/src/Payutc/Bom/User.php
+++ b/src/Payutc/Bom/User.php
@@ -407,10 +407,6 @@ class User {
         if(($this->getCredit() + $amount) > $credit_max){
             throw new CannotReload("Le rechargement ferait dépasser le plafond maximum");
         }
-        
-        if(!$this->isCotisant()){
-            throw new CannotReload("Il faut être cotisant pour pouvoir recharger");
-        }
     }
 
     /**

--- a/src/Payutc/Bom/User.php
+++ b/src/Payutc/Bom/User.php
@@ -419,7 +419,9 @@ class User {
      */
     public function transfer($amount, $userID, $message="") {
         $message = htmlspecialchars($message);
-        if($amount < 0) {
+        if(!$this->user()->isCotisant()) {
+            throw new TransferException("Les non cotisants ne peuvent pas utiliser la fonction virement.");
+        } else if($amount < 0) {
             Log::warn("TRANSFERT: Montant négatif par l'userID ".$this->getId()." vers l'user ".$userID);
             throw new TransferException("Tu ne peux pas faire un virement négatif (bien essayé)");
         } else if($amount == 0) {

--- a/src/Payutc/Migrations/Version20140723153558.php
+++ b/src/Payutc/Migrations/Version20140723153558.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Payutc\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+    Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add a column to know if an article is exclusively open to cotisant
+ */
+class Version20140723153558 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql("ALTER TABLE `t_object_obj`
+            ADD `obj_cotisant` INT(1) NOT NULL DEFAULT '1' COMMENT 'Is this object cotisant only' AFTER `obj_alcool`");
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql("ALTER TABLE `t_object_obj`
+            DROP `obj_cotisant`");
+    }
+}

--- a/src/Payutc/Service/GESARTICLE.php
+++ b/src/Payutc/Service/GESARTICLE.php
@@ -97,12 +97,12 @@ class GESARTICLE extends \ServiceBase {
     /**
     * Ajoute (ou edite) un article
     */
-    public function setProduct($obj_id = null, $name, $parent, $prix, $stock, $alcool, $image, $fun_id, $tva=0.00) {
+    public function setProduct($obj_id = null, $name, $parent, $prix, $stock, $alcool, $image, $fun_id, $tva=0.00, $cotisant=1) {
         $this->checkRight(true, true, true, $fun_id);
         if($obj_id) {
-            return Product::edit($obj_id, $name, $parent, $prix, $stock, $alcool, $image, $fun_id, $tva);
+            return Product::edit($obj_id, $name, $parent, $prix, $stock, $alcool, $image, $fun_id, $tva, $cotisant);
         } else {
-            return Product::add($name, $parent, $prix, $stock, $alcool, $image, $fun_id, $tva);
+            return Product::add($name, $parent, $prix, $stock, $alcool, $image, $fun_id, $tva, $cotisant);
         }
     }
 

--- a/src/Payutc/Service/MYACCOUNT.php
+++ b/src/Payutc/Service/MYACCOUNT.php
@@ -83,7 +83,18 @@ class MYACCOUNT extends \ServiceBase {
             "historique" => $this->user()->getHistorique(),
             "credit" => $this->user()->getCredit());
 	}
-	
+
+    /**
+    * Recupere le statut de la cotisation de l'utilisateur
+    * Utile pour ne pas afficher les modules qui lui sont "bloqués" comme le virement
+    * Et pour lui afficher un lien de rappel lui permettant d'aller cotiser directement en ligne.
+    * @return boolean 
+    */
+    public function isCotisant() {
+        return $this->user()->isCotisant();
+    }
+
+
 	/**
 	* Definit le blocage de la carte de l'utilisateur (par lui même, en cas de perte par exemple)
 	* @param int (0/1)

--- a/tests/Payutc/Bom/ProductRodbTest.php
+++ b/tests/Payutc/Bom/ProductRodbTest.php
@@ -30,6 +30,7 @@ class ProductRodbTest extends ReadOnlyDatabaseTest
                  "price" => "100",
                  "tva" => "7",
                  "alcool" => "0",
+                 "cotisant" => "1",
                  "image" => null
             ),
             array(
@@ -41,6 +42,7 @@ class ProductRodbTest extends ReadOnlyDatabaseTest
                  "price" => "80",
                  "tva" => "7",
                  "alcool" => "0",
+                 "cotisant" => "1",
                  "image" => null
             ),
             array(
@@ -52,6 +54,7 @@ class ProductRodbTest extends ReadOnlyDatabaseTest
                  "price" => "170",
                  "tva" => "19.6",
                  "alcool" => "0",
+                 "cotisant" => "1",
                  "image" => null
             ),
             array(
@@ -63,6 +66,7 @@ class ProductRodbTest extends ReadOnlyDatabaseTest
                  "price" => "150",
                  "tva" => "19.6",
                  "alcool" => "0",
+                 "cotisant" => "1",
                  "image" => null
             ),
             array(
@@ -74,6 +78,7 @@ class ProductRodbTest extends ReadOnlyDatabaseTest
                  "price" => "170",
                  "tva" => "19.6",
                  "alcool" => "0",
+                 "cotisant" => "1",
                  "image" => null
             ),
         );
@@ -96,6 +101,7 @@ class ProductRodbTest extends ReadOnlyDatabaseTest
              "price" => "100",
              "tva" => "7",
              "alcool" => "0",
+             "cotisant" => "1",
              "image" => null
         );
         $r = Product::getOne(1,1);
@@ -109,6 +115,7 @@ class ProductRodbTest extends ReadOnlyDatabaseTest
              "price" => "80",
              "tva" => "7",
              "alcool" => "0",
+             "cotisant" => "1",
              "image" => null
         );
         $r = Product::getOne(2,1);

--- a/tests/Payutc/Bom/ProductRwdbTest.php
+++ b/tests/Payutc/Bom/ProductRwdbTest.php
@@ -34,7 +34,7 @@ class ProductRwdbTest extends DatabaseTest
     }
 
     public function testAdd() {
-        $a = Product::add("Chouffe", 1000, 180, 10, 1, null, 1, 19.6);
+        $a = Product::add("Chouffe", 1000, 180, 10, 1, null, 1, 19.6, 0);
         $r = Product::getOne($a["success"], 1);
 
         $this->assertEquals("Chouffe", $r['name']);
@@ -45,8 +45,9 @@ class ProductRwdbTest extends DatabaseTest
         $this->assertEquals(null, $r['image']);
         $this->assertEquals(1000, $r['categorie_id']);
         $this->assertEquals(1, $r['fundation_id']);
+        $this->assertEquals(0, $r['cotisant']);
         
-        $a = Product::edit($r["id"], "MC Chouffe", 1001, 170, 10, 1, null, 1, 20);
+        $a = Product::edit($r["id"], "MC Chouffe", 1001, 170, 10, 1, null, 1, 20, 1);
         $r = Product::getOne($a["success"]);
 
         $this->assertEquals("MC Chouffe", $r['name']);
@@ -57,8 +58,9 @@ class ProductRwdbTest extends DatabaseTest
         $this->assertEquals(null, $r['image']);
         $this->assertEquals(1001, $r['categorie_id']);
         $this->assertEquals(1, $r['fundation_id']);
+        $this->assertEquals(1, $r['cotisant']);
 
-        $a = Product::edit($r["id"], "MC Chouffe", 1001, 170, 10, 0, null, 1, 20);
+        $a = Product::edit($r["id"], "MC Chouffe", 1001, 170, 10, 0, null, 1, 20, 1);
         $r = Product::getOne($a["success"]);
         $this->assertEquals(0, $r['alcool']);
 
@@ -89,7 +91,7 @@ class ProductRwdbTest extends DatabaseTest
                 'img_length' => 0,
                 'img_content' => ''));
         // create object
-        $a = Product::add("Chouffe", 1000, 180, 10, 1, $img_id, 1, 19.6);
+        $a = Product::add("Chouffe", 1000, 180, 10, 1, $img_id, 1, 19.6, 1);
         $id = $a["success"];
         // delete object
         Product::delete($id, 1);

--- a/tests/Payutc/Bom/UserRwTest.php
+++ b/tests/Payutc/Bom/UserRwTest.php
@@ -52,5 +52,15 @@ class UserDatabaseTest extends DatabaseTest
         $u = new User("trecouvr");
         $this->assertEquals(8900, $u->getCredit());
     }
+
+
+    /**
+     * @requires PHP 5.4
+     */
+    public function testisCotisant()
+    {
+        $u = new User("trecouvr");
+        $this->assertEquals(true, $u->isCotisant());
+    }
 }
 

--- a/tests/Payutc/Service/WebsaleConfirmRwdbTest.php
+++ b/tests/Payutc/Service/WebsaleConfirmRwdbTest.php
@@ -75,6 +75,7 @@ class WebsaleConfirmRwdbTest extends DatabaseTest
                             "stock" => 42,
                             "price" => 170,
                             "alcool" => 0,
+                            "cotisant" => 1,
                             "image" => "",                            
                             "tva" => 19.60
                         )


### PR DESCRIPTION
L'ancienne politique de gestion des non cotisants n'était pas au top, elle pouvait rendre bloquant le passage au moment du paiement en ligne, et facilitait un peu trop la fraude à la cotisation en permettant de recharger sur le compte d'un autre puis de recevoir un virement et utiliser payutc normalement...

En plus, de nouveaux accepteurs ont besoin d'accepter de l'argent venant de non cotisants.

Du coup la nouvelle politique consiste à : 
- Accepter les rechargements des non cotisants
- Empêcher les virements sortants d'un non cotisant
- Laisser le libre arbitre à l'accepteur de définir si l'article est achetable ou non par un non cotisant
  (=> Cette feature n'est pas utilisé pour la vente en ligne, car elle n'a pas de sens dans ce cas la. Mais à l'avenir on pourrait définir que si l'article n'est pas ouvert au non cotisant (cotisant only) alors le paiement en ligne saute une étape et rentre automatiquement dans le cas "J'ai un compte payutc".

PS: Le code est rétro-compatible avec les clients actuels, mais je fais des PR au plus vite, ne serait-ce que pour pouvoir tester le bon fonctionnement des nouvelles features (Coté casper c'est déjà fait)
